### PR TITLE
make removeSelectors and hideSelectors use querySelectorAll

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -80,7 +80,7 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 				//HIDE SELECTORS WE WANT TO AVOID
 				grabConfig.hideSelectors.forEach(function(o,i,a){
 					casper.evaluate(function(o){
-						document.querySelectorAll(o).forEach(function(s){
+						Array.prototype.forEach.call(document.querySelectorAll(o), function(s, j){
 							s.style.visibility='hidden';
 						});
 					},o);
@@ -89,12 +89,12 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 				//REMOVE UNWANTED SELECTORS FROM RENDER TREE
 				grabConfig.removeSelectors.forEach(function(o,i,a){
 					casper.evaluate(function(o){
-						document.querySelectorAll(o).forEach(function(s){
+						Array.prototype.forEach.call(document.querySelectorAll(o), function(s, j){
 							s.style.display='none';
 						});
 					},o);
 				});
-
+				
 				//CREATE SCREEN SHOTS AND TEST COMPARE CONFIGURATION (CONFIG FILE WILL BE SAVED WHEN THIS PROCESS RETURNS)
 				grabConfig.selectors.forEach(function(o,i,a){
 					var cleanedSelectorName = o.replace(/[^a-zA-Z\d]/,'');//remove anything that's not a letter or a number 				


### PR DESCRIPTION
It is important to remove or hide every selector on page but not only the first one

btw thanks for the useful tool
