### PR TITLE
Simplify the config structure to improve usability

### DIFF
--- a/capture/config.default.json
+++ b/capture/config.default.json
@@ -2,20 +2,23 @@
 	"viewports" : [
 		{
 		 "name": "phone",
-		 "viewport": {"width": 320, "height": 480}
+		 "width": 320,
+     "height": 480
 		}
 		,{
 		 "name": "tablet_v",
-		 "viewport": {"width": 568, "height": 1024}
+		 "width": 568,
+     "height": 1024
 		}
 		,{
 		 "name": "tablet_h",
-		 "viewport": {"width": 1024, "height": 768}
+		 "width": 1024,
+     "height": 768
 		}
 	]
-	,"grabConfigs" : [
+	,"scenarios" : [
 		{
-			"testName":"http://getbootstrap.com"
+			"label":"http://getbootstrap.com"
 			,"url":"http://getbootstrap.com"
 			,"hideSelectors": [
 			]

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -67,19 +67,19 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 
 
-	casper.each(scenarios,function(casper, grabConfig, grabConfig_index){
+	casper.each(scenarios,function(casper, scenario, scenario_index){
 
 
 		casper.each(viewports, function(casper, vp, viewport_index) {
 			this.then(function() {
 				this.viewport(vp.width, vp.height);
 			});
-			this.thenOpen(grabConfig.url, function() {
+			this.thenOpen(scenario.url, function() {
 
 				casper.waitFor(
 					function(){ //test
-						if(!grabConfig.readyEvent)return true;
-						var regExReadyFlag = new RegExp(grabConfig.readyEvent,'i');
+						if(!scenario.readyEvent)return true;
+						var regExReadyFlag = new RegExp(scenario.readyEvent,'i');
 						return consoleBuffer.search(regExReadyFlag)>=0;
 					}
 					,function(){//on done
@@ -89,11 +89,11 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 					,function(){casper.echo('ERROR: casper timeout.')} //on timeout
 					,scriptTimeout
 				);
-				casper.wait(grabConfig.delay||1);
+				casper.wait(scenario.delay||1);
 
 			});
 			casper.then(function() {
-				this.echo('Current location is ' + grabConfig.url, 'info');
+				this.echo('Current location is ' + scenario.url, 'info');
 
 				//var src = this.evaluate(function() {return document.body.outerHTML; });
 				//this.echo(src);
@@ -104,8 +104,8 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 				this.echo('Screenshots for ' + vp.name + ' (' + vp.width + 'x' + vp.height + ')', 'info');
 
 				//HIDE SELECTORS WE WANT TO AVOID
-		        if ( grabConfig.hasOwnProperty('hideSelectors') ) {
-		  				grabConfig.hideSelectors.forEach(function(o,i,a){
+		        if ( scenario.hasOwnProperty('hideSelectors') ) {
+		  				scenario.hideSelectors.forEach(function(o,i,a){
 		  					casper.evaluate(function(o){
 		  						Array.prototype.forEach.call(document.querySelectorAll(o), function(s, j){
 		  							s.style.visibility='hidden';
@@ -115,8 +115,8 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 		        }
 
 				//REMOVE UNWANTED SELECTORS FROM RENDER TREE
-		        if ( grabConfig.hasOwnProperty('removeSelectors') ) {
-		  				grabConfig.removeSelectors.forEach(function(o,i,a){
+		        if ( scenario.hasOwnProperty('removeSelectors') ) {
+		  				scenario.removeSelectors.forEach(function(o,i,a){
 		  					casper.evaluate(function(o){
 		  						Array.prototype.forEach.call(document.querySelectorAll(o), function(s, j){
 		  							s.style.display='none';
@@ -127,13 +127,13 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 				//CREATE SCREEN SHOTS AND TEST COMPARE CONFIGURATION (CONFIG FILE WILL BE SAVED WHEN THIS PROCESS RETURNS)
 		        // If no selectors are provided then set the default 'body'
-		        if ( !grabConfig.hasOwnProperty('selectors') ) {
-		          grabConfig.selectors = [ 'body' ];
+		        if ( !scenario.hasOwnProperty('selectors') ) {
+		          scenario.selectors = [ 'body' ];
 		        }
-				grabConfig.selectors.forEach(function(o,i,a){
+				scenario.selectors.forEach(function(o,i,a){
 					var cleanedSelectorName = o.replace(/[^a-zA-Z\d]/,'');//remove anything that's not a letter or a number
-					//var cleanedUrl = grabConfig.url.replace(/[^a-zA-Z\d]/,'');//remove anything that's not a letter or a number
-					var fileName = grabConfig_index + '_' + i + '_' + cleanedSelectorName + '_' + viewport_index + '_' + vp.name + '.png';;
+					//var cleanedUrl = scenario.url.replace(/[^a-zA-Z\d]/,'');//remove anything that's not a letter or a number
+					var fileName = scenario_index + '_' + i + '_' + cleanedSelectorName + '_' + viewport_index + '_' + vp.name + '.png';;
 
 					var reference_FP 	= bitmaps_reference + '/' + fileName;
 					var test_FP 			= bitmaps_test + '/' + screenshotDateTime + '/' + fileName;
@@ -146,7 +146,7 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 							test:test_FP,
 							selector:o,
 							fileName:fileName,
-							testName:grabConfig.testName
+							label:scenario.label
 						})
 
 					casper.captureSelector(filePath, o);
@@ -158,7 +158,7 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 		});//end casper.each viewports
 
-	});//end casper.each grabConfig
+	});//end casper.each scenario
 
 }
 

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -13,7 +13,7 @@ var configJSON = fs.read(genConfigPath);
 var config = JSON.parse(configJSON);
 
 var viewports = config.viewports;
-var grabConfigs = config.grabConfigs;
+var scenarios = config.scenarios;
 
 var compareConfig = {testPairs:[]};
 
@@ -45,7 +45,7 @@ casper.on('resource.received', function(resource) {
 
 
 
-function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmaps_test,isReference){
+function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_test,isReference){
 
 	var
 		screenshotNow = new Date(),
@@ -67,12 +67,12 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 
 
 
-	casper.each(grabConfigs,function(casper, grabConfig, grabConfig_index){
+	casper.each(scenarios,function(casper, grabConfig, grabConfig_index){
 
 
 		casper.each(viewports, function(casper, vp, viewport_index) {
 			this.then(function() {
-				this.viewport(vp.viewport.width, vp.viewport.height);
+				this.viewport(vp.width, vp.height);
 			});
 			this.thenOpen(grabConfig.url, function() {
 
@@ -82,10 +82,10 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 						var regExReadyFlag = new RegExp(grabConfig.readyEvent,'i');
 						return consoleBuffer.search(regExReadyFlag)>=0;
 					}
-					,function(){//on done 
-						consoleBuffer = ''; 
+					,function(){//on done
+						consoleBuffer = '';
 						casper.echo('Ready event received.');
-					} 
+					}
 					,function(){casper.echo('ERROR: casper timeout.')} //on timeout
 					,scriptTimeout
 				);
@@ -101,7 +101,7 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 
 			this.then(function(){
 
-				this.echo('Screenshots for ' + vp.name + ' (' + vp.viewport.width + 'x' + vp.viewport.height + ')', 'info');
+				this.echo('Screenshots for ' + vp.name + ' (' + vp.width + 'x' + vp.height + ')', 'info');
 
 				//HIDE SELECTORS WE WANT TO AVOID
 		        if ( grabConfig.hasOwnProperty('hideSelectors') ) {
@@ -153,7 +153,7 @@ function capturePageSelectors(url,grabConfigs,viewports,bitmaps_reference,bitmap
 					//casper.echo('remote capture to > '+filePath,'info');
 
 				});//end topLevelModules.forEach
-				
+
 			});
 
 		});//end casper.each viewports
@@ -174,7 +174,7 @@ if(!exists){isReference=true; console.log('CREATING NEW REFERENCE FILES')}
 
 capturePageSelectors(
 	'index.html'
-	,grabConfigs
+	,scenarios
 	,viewports
 	,bitmaps_reference
 	,bitmaps_test

--- a/compare/index.html
+++ b/compare/index.html
@@ -63,8 +63,8 @@
 
 
 		var testPairObj = function(a,b,c,o){
-			this.a={src:a||'',srcClass:'reference'}, 
-			this.b={src:b||'',srcClass:'test'},	
+			this.a={src:a||'',srcClass:'reference'},
+			this.b={src:b||'',srcClass:'test'},
 			this.c={src:c||'',srcClass:'diff'},
 			this.report=null;
 			this.processing=true;
@@ -103,7 +103,7 @@
 					$scope.testPairs.push(new testPairObj('../'+o.reference, '../'+o.test, null, o));
 				});
 				$scope.compareTestPairs($scope.testPairs);
-		
+
 			})
 			.error(function(data, status) {
 				console.log('config file operation failed '+status);
@@ -249,24 +249,24 @@
 						<div class="indicator passed" ng-if="thisTestPair.passed"><span class="dot green"></span>passed</span>
 					</td>
 					<td>
-						{{ thisTestPair.meta.testName }} {{ thisTestPair.meta.selector }} <span class="fileName">{{ thisTestPair.meta.fileName }}</span>
+						{{ thisTestPair.meta.label }} {{ thisTestPair.meta.selector }} <span class="fileName">{{ thisTestPair.meta.fileName }}</span>
 					</td>
 				</tr>
 			</table>
 		</div> <!-- end summaryBlock -->
 
 		<div class="detailReport">
-		
+
 			<div class='filterGroup form-group'>
 				<label for="statusFilter" class="control-label">status filter</label>
 				<select id="statusFilter" class="form-control" ng-model="statusFilter" ng-options="status for status in detailFilterOptions"></select>
 
 			</div>
-			
+
 			<table ng-repeat="thisTestPair in testPairs | filter : displayOnStatusFilter ">
 				<thead>
 					<tr>
-						<th class="selector" colspan="2">{{ thisTestPair.meta.testName }} {{ thisTestPair.meta.selector }}</th>
+						<th class="selector" colspan="2">{{ thisTestPair.meta.label }} {{ thisTestPair.meta.selector }}</th>
 						<th class="filename" colspan="2">{{ thisTestPair.meta.fileName }}</th>
 					</tr>
 					<tr>


### PR DESCRIPTION
I'm giving a presentation on this tool next week, comparing how simple it is to use compared to a tool like PhantomCSS. I've been including config examples in my slides which means I've been thinking a lot about how to simplify them so the on boarding process on getting up and running is even smoother.

  {
     "name": "phone",
     "viewport":  {"width": 320, "height": 480 }
  }

Why wrap the dimensions in another object? Each viewport is already wrapped in the array 'viewports' so it feels like we could simplify the structure here.

  {
     "name": "phone",
     "width": 320, 
    "height": 480 
  }


  "grabConfigs" 

The name of this array is a little nondescript, it would be better if it described the items it contains like the "viewports" array does. How about "pages" or "tests"?

  {
    "testName":"Home",
    "url":"http://example.com/"
  }

If we rename the "genConfig" array to be more descriptive, we could probably just rename "testName" to "name".

This will break existing builds so it would have to be included in a major version update or we just support both the new and existing config structure for a while.

What do you think? 