### PR TITLE
Add `cookiesJsonFile` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,22 @@ In the following case, BackstopJS would wait for one second after the string `ba
     "delay": 1000 //delay in ms
     }
 
+####set HTTP cookie for login-required pages
 
+The `cookiesJsonFile` property enables you to add HTTP cookie for capturing login-required pages.
+
+    "cookiesJsonFile": "./path/to/cookies.json"
+
+The `cookiesJsonFile` file should have this format.
+
+    [
+      {
+        "name": "mycookie",
+        "value": "1",
+        "domain": "localhost",
+        "path": "/"
+      }
+    ]
 
 
 ### dealing with dynamic content

--- a/capture/echoFiles.js
+++ b/capture/echoFiles.js
@@ -58,7 +58,7 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 	casper.each(scenarios,function(casper, scenario, scenario_index){
 
-		if (fs.isFile(scenario.cookiesJsonFile)) {
+		if (scenario.cookiesJsonFile && fs.isFile(scenario.cookiesJsonFile)) {
 			var cookiesJson = fs.read(scenario.cookiesJsonFile);
 			var cookies = JSON.parse(cookiesJson);
 			for (var i = 0; i < cookies.length; i++) {

--- a/capture/echoFiles.js
+++ b/capture/echoFiles.js
@@ -58,6 +58,13 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 	casper.each(scenarios,function(casper, scenario, scenario_index){
 
+		if (fs.isFile(scenario.cookiesJsonFile)) {
+			var cookiesJson = fs.read(scenario.cookiesJsonFile);
+			var cookies = JSON.parse(cookiesJson);
+			for (var i = 0; i < cookies.length; i++) {
+				phantom.addCookie(cookies[i]);
+			}
+		}
 
 		// casper.each(viewports, function(casper, vp, viewport_index) {
 			// this.then(function() {

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -69,6 +69,13 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 	casper.each(scenarios,function(casper, scenario, scenario_index){
 
+		if (fs.isFile(scenario.cookiesJsonFile)) {
+			var cookiesJson = fs.read(scenario.cookiesJsonFile);
+			var cookies = JSON.parse(cookiesJson);
+			for (var i = 0; i < cookies.length; i++) {
+				phantom.addCookie(cookies[i]);
+			}
+		}
 
 		casper.each(viewports, function(casper, vp, viewport_index) {
 			this.then(function() {

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -69,7 +69,7 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
 	casper.each(scenarios,function(casper, scenario, scenario_index){
 
-		if (fs.isFile(scenario.cookiesJsonFile)) {
+		if (scenario.cookiesJsonFile && fs.isFile(scenario.cookiesJsonFile)) {
 			var cookiesJson = fs.read(scenario.cookiesJsonFile);
 			var cookies = JSON.parse(cookiesJson);
 			for (var i = 0; i < cookies.length; i++) {


### PR DESCRIPTION
Hi @garris 
This is pull request for https://github.com/garris/BackstopJS/issues/44.

Add patch for capture/echoFiles.js and capture/genBitmaps.js.
If `scenario` has `cookiesJsonFile` property, BackstopJS assumes it as a path of JSON file, reads cookies from the file, and sets cookies to PhantomJS object.
This enables BackstopJS to take screen capture for login-required pages.

Add explanation of `cookiesJsonFile` property to README.md.
It includes short explanation and example contents of `cookiesJsonFile`.
It helps users to learn what it is, and how to deal with it.