### PR TITLE
Adding label to console log compare output.

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -45,10 +45,10 @@ gulp.task('compare', function (done) {
 
       if (imageComparisonFailed) {
         pair.testStatus = "fail";
-        console.log('ERROR:', pair.fileName);
+        console.log('ERROR:', pair.label, pair.fileName);
       } else {
         pair.testStatus = "pass";
-        console.log('OK:', pair.fileName);
+        console.log('OK:', pair.label, pair.fileName);
       }
       updateProgress();
     });


### PR DESCRIPTION
This adds the label to the comparison results shown in command line report.

Currently the results are too cryptic to decipher as the filename doesn't contain information to let the user know which page/component is failing/succeeding. (A unique number is used at the beginning of the filename, but that number doesn't intuitively translate into a specific page/component to the user running the test.)

