### PR TITLE
Specify path for the backstop.json config file - feature #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ There may also be elements which need to be completely removed during testing. F
     "removeSelectors": [
     	"#someUnpredictableSizedDomSelector"
     ]
-    
+
 ### Running custom CasperJS scripts (version 0.8.0+)
 
 Simulate user actions (click, scroll, hover, wait, etc.) by running your own Casper.js script on ready. For each scenario, the custom .js file you specify is imported and run when the BackstopJS ready event is fired.
@@ -308,7 +308,7 @@ Simulate user actions (click, scroll, hover, wait, etc.) by running your own Cas
 From your project root, place your scripts in...
 
     ./backstop_data/casper_scripts
-    
+
 And in your scenario...
 
     "onReadyScript": "filename.js"   // the .js suffix is optional
@@ -366,9 +366,9 @@ If you choose the CLI-only reporting you can always enter the following command 
     $ gulp openReport
 
 
-####CLI error handling 
+####CLI error handling
 
-When a layout error is found in CLI mode, BackstopJS will let you know in a general report displayed in the console. Optionally, BackstopJS can throw an error that can be passed to calling process. For this behavior enable `cliExitOnFail` in your config... 
+When a layout error is found in CLI mode, BackstopJS will let you know in a general report displayed in the console. Optionally, BackstopJS can throw an error that can be passed to calling process. For this behavior enable `cliExitOnFail` in your config...
 
 ```
 "cliExitOnFail": true,
@@ -412,7 +412,14 @@ Thats it.
 
 This is a new feature, so if you find any bugs, [please file an issue.](https://github.com/garris/BackstopJS/issues)
 
+### Specifying which backstop.json configuration file to use on the CLI
+If you have multiple backstop.json configuration files you would like to use you can specify which one you should run when running the gulp task
 
+The location of the configuration file can be specified by passing a backstopConfig argument to the gulp tasks.
+```
+$ gulp reference --backstopConfig=test/backstop2.json
+$ gulp test --backstopConfig=test/backstop2.json
+```
 
 ### Troubleshooting
 
@@ -438,7 +445,7 @@ To enable verbose console output when running your tests set the `debug` propert
 
 #### View file contents
 
-Sometimes it also helps to verify that BackstopJS is receiving the correct file contents. Enabling the `debug` property (above) will output this data to the console whenever a test is run. 
+Sometimes it also helps to verify that BackstopJS is receiving the correct file contents. Enabling the `debug` property (above) will output this data to the console whenever a test is run.
 
 You can also use the following command -- it will output your file contents to the console.
 

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -47,9 +47,7 @@ paths.serverPidFile                 = paths.backstop + '/server.pid';
 
 // Get different backstop.json if it is passed in as an option
 function getBackstopConfig() {
-	console.log("in backstop config");
 	if(argv.backstopConfig) {
-		console.log(argv.backstopConfig);
 		if(argv.backstopConfig.substr(-5) !== '.json') {
 			throw new Error('Backstop config file has to be a .json file');
 		}
@@ -69,6 +67,16 @@ function getBackstopConfig() {
 }
 // ACTIVE CAPTURE CONFIG PATH
 paths.activeCaptureConfigPath       = getBackstopConfig();
+
+// if(!fs.existsSync(paths.backstopConfigFileName)){
+//   // console.log('\nCould not find a valid config file.');
+//   console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
+//   console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
+//   paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
+// }else{
+//   console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
+//   paths.activeCaptureConfigPath = paths.backstopConfigFileName;
+// }
 
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -65,12 +65,11 @@ function getBackstopConfig() {
 	  // console.log('\nCould not find a valid config file.');
 	  console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
 	  console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
-	  paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
+	  return paths.captureConfigFileNameDefault;
 	}else{
 	  console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
-	  paths.activeCaptureConfigPath = paths.backstopConfigFileName;
+	  return paths.backstopConfigFileName;
 	}
-	return paths.captureConfigFileNameDefault;
 }
 // ACTIVE CAPTURE CONFIG PATH
 paths.activeCaptureConfigPath       = getBackstopConfig();

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -61,22 +61,19 @@ function getBackstopConfig() {
 		return configPath;
 	}
 	// Did not pass in a different config, use default
-	console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
-	console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
+	if(!fs.existsSync(paths.backstopConfigFileName)){
+	  // console.log('\nCould not find a valid config file.');
+	  console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
+	  console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
+	  paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
+	}else{
+	  console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
+	  paths.activeCaptureConfigPath = paths.backstopConfigFileName;
+	}
 	return paths.captureConfigFileNameDefault;
 }
 // ACTIVE CAPTURE CONFIG PATH
 paths.activeCaptureConfigPath       = getBackstopConfig();
-
-// if(!fs.existsSync(paths.backstopConfigFileName)){
-//   // console.log('\nCould not find a valid config file.');
-//   console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
-//   console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
-//   paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
-// }else{
-//   console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
-//   paths.activeCaptureConfigPath = paths.backstopConfigFileName;
-// }
 
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -70,16 +70,6 @@ function getBackstopConfig() {
 // ACTIVE CAPTURE CONFIG PATH
 paths.activeCaptureConfigPath       = getBackstopConfig();
 
-// if(!fs.existsSync(paths.backstopConfigFileName)){
-//   // console.log('\nCould not find a valid config file.');
-//   console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
-//   console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
-//   paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
-// }else{
-//   console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
-//   paths.activeCaptureConfigPath = paths.backstopConfigFileName;
-// }
-
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){
   var configJSON = fs.readFileSync(paths.activeCaptureConfigPath, "utf8");

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -45,18 +45,40 @@ paths.casper_scripts_default        = paths.backstop + '/capture/casper_scripts'
 // SERVER PID PATH
 paths.serverPidFile                 = paths.backstop + '/server.pid';
 
-// ACTIVE CAPTURE CONFIG PATH
-paths.activeCaptureConfigPath       = '';
-
-if(!fs.existsSync(paths.backstopConfigFileName)){
-  // console.log('\nCould not find a valid config file.');
-  console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
-  console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
-  paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
-}else{
-  console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
-  paths.activeCaptureConfigPath = paths.backstopConfigFileName;
+// Get different backstop.json if it is passed in as an option
+function getBackstopConfig() {
+	console.log("in backstop config");
+	if(argv.backstopConfig) {
+		console.log(argv.backstopConfig);
+		if(argv.backstopConfig.substr(-5) !== '.json') {
+			throw new Error('Backstop config file has to be a .json file');
+		}
+		var isAbsolutePath = argv.backstopConfig.charAt(0) === '/';
+		var configPath = isAbsolutePath ? argv.backstopConfig : path.join(paths.backstop, argv.backstopConfig);
+		if(!fs.existsSync(configPath)) {
+			throw new Error('Couldn\'t resolve backstop config file');
+		}
+		// Passed in different config, use passed in file
+		console.log('\nBackstopJS Config loaded at location', paths.backstopConfig);
+		return configPath;
+	}
+	// Did not pass in a different config, use default
+	console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
+	console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
+	return paths.captureConfigFileNameDefault;
 }
+// ACTIVE CAPTURE CONFIG PATH
+paths.activeCaptureConfigPath       = getBackstopConfig();
+
+// if(!fs.existsSync(paths.backstopConfigFileName)){
+//   // console.log('\nCould not find a valid config file.');
+//   console.log('\nCurrent config file location...\n ==> '+paths.backstopConfigFileName);
+//   console.log('\n`$ gulp genConfig` generates a configuration boilerplate file in `' + paths.backstopConfigFileName + '`. (Will overwrite existing files.)\n')
+//   paths.activeCaptureConfigPath = paths.captureConfigFileNameDefault;
+// }else{
+//   console.log('\nBackstopJS Config loaded at location', paths.backstopConfigFileName);
+//   paths.activeCaptureConfigPath = paths.backstopConfigFileName;
+// }
 
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){


### PR DESCRIPTION
We are looking to use backstop.js across multiple teams and it would be great to allow each team have their own config file.

Trying to solve this issue:
https://github.com/garris/BackstopJS/issues/87