### PR TITLE
Saves image-diffs when using the CLI reporter #121

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -17,14 +17,14 @@ gulp.task('compare', function (done) {
       }
       !results[pair.testStatus]++;
     });
-    if (!results.running){
-      console.log ("\nTest completed...")
-      console.log ((results.pass || 0) + " Passed")
-      console.log ((results.fail || 0) + " Failed\n")
+    if (!results.running) {
+      console.log ("\nTest completed...");
+      console.log ((results.pass || 0) + " Passed");
+      console.log ((results.fail || 0) + " Failed\n");
 
       if (results.fail) {
-        console.log ("*** Mismatch errors found ***")
-        console.log ("For a detailed report run `gulp openReport`\n")
+        console.log ("*** Mismatch errors found ***");
+        console.log ("For a detailed report run `gulp openReport`\n");
         if (paths.cliExitOnFail) {
           done(new Error('Mismatch errors found.'));
         }
@@ -42,12 +42,13 @@ gulp.task('compare', function (done) {
     var referencePath = path.join(paths.backstop, pair.reference);
     var testPath = path.join(paths.backstop, pair.test);
 
-    resemble(referencePath).compareTo(testPath).onComplete(function(data) {
+    resemble(referencePath).compareTo(testPath).onComplete(function (data) {
       var imageComparisonFailed = !data.isSameDimensions || data.misMatchPercentage > pair.misMatchThreshold;
 
       if (imageComparisonFailed) {
         pair.testStatus = "fail";
         console.log('ERROR:', pair.label, pair.fileName);
+        storeFailedDiffImage(testPath, data);
       } else {
         pair.testStatus = "pass";
         console.log('OK:', pair.label, pair.fileName);
@@ -55,4 +56,16 @@ gulp.task('compare', function (done) {
       updateProgress();
     });
   });
+
+  function storeFailedDiffImage(testPath, data) {
+    var failedDiffFilename = getFailedDiffFilename(testPath);
+    console.log('Storing diff image in ', failedDiffFilename);
+    var failedDiffStream = fs.createWriteStream(failedDiffFilename);
+    data.getDiffImage().pack().pipe(failedDiffStream)
+  }
+
+  function getFailedDiffFilename(testPath) {
+    var lastSlash = testPath.lastIndexOf('/');
+    return testPath.slice(0, lastSlash + 1) + 'failed_diff_' + testPath.slice(lastSlash + 1, testPath.length);
+  }
 });


### PR DESCRIPTION
Saves diff images of failed diffs in the paths.bitmaps_test/[timestamp]
 directory