### PR TITLE
Use "require" to load config

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ $ gulp test --backstopConfigFilePath=../../backstopTests/someTest.json
 
 NOTE: all paths are relative to the location of the BackstopJS install directory _(which is either inside your project's `node_modules` or `bower_components` depending on how BackstopJS was installed)_
 
+###Using a js based config file
+
+For advanced configuration, you can use a js based config file rather than plain JSON. Using JavaScript in the config file makes it possible to use comments and variables etc. in the configuration.
+
+To use a js based config file, simply use [`--backstopConfigFilePath`](#setting-the-config-file-path-version-090) and point to a js file, e.g.
+```
+$ gulp reference --backstopConfigFilePath=someTest.js
+```
+
+See [configExample.js](test/configExample.js) for a simple example on how to specify a js based config.
 
 
 ### Setting the bitmap and script directory paths (version 0.6.0+)

--- a/gulp/tasks/_init_.js
+++ b/gulp/tasks/_init_.js
@@ -1,4 +1,6 @@
 var paths                   = require('../util/paths');
-var fse                     = require('fs-extra');
+var fs                     = require('fs');
 
-fse.copySync(paths.activeCaptureConfigPath,paths.captureConfigFileName);
+var config = require(paths.activeCaptureConfigPath);
+// Serialize config as JSON into capture config.
+fs.writeFileSync(paths.captureConfigFileName, JSON.stringify(config));

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -61,7 +61,6 @@ if(!fs.existsSync(paths.backstopConfigFileName)){
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){
   var config = require(paths.activeCaptureConfigPath);
-
   if (config.paths) {
     paths.bitmaps_reference = config.paths.bitmaps_reference || paths.bitmaps_reference;
     paths.bitmaps_test = config.paths.bitmaps_test || paths.bitmaps_test;

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -9,9 +9,6 @@ paths.backstop                      = path.join(__dirname, '../..');
 
 function getBackstopConfigFileName() {
 	if(argv.backstopConfigFilePath) {
-		if(!/\.js(on)?$/.test(argv.backstopConfigFilePath)) {
-			throw new Error('Backstop config file has to be a .js or .json file');
-		}
 		var isAbsolutePath = argv.backstopConfigFilePath.charAt(0) === '/';
 		var configPath = isAbsolutePath ? argv.backstopConfigFilePath : path.join(paths.backstop, argv.backstopConfigFilePath);
 		if(!fs.existsSync(configPath)) {

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -9,8 +9,8 @@ paths.backstop                      = path.join(__dirname, '../..');
 
 function getBackstopConfigFileName() {
 	if(argv.backstopConfigFilePath) {
-		if(argv.backstopConfigFilePath.substr(-5) !== '.json') {
-			throw new Error('Backstop config file has to be a .json file');
+		if(!/\.js(on)?$/.test(argv.backstopConfigFilePath)) {
+			throw new Error('Backstop config file has to be a .js or .json file');
 		}
 		var isAbsolutePath = argv.backstopConfigFilePath.charAt(0) === '/';
 		var configPath = isAbsolutePath ? argv.backstopConfigFilePath : path.join(paths.backstop, argv.backstopConfigFilePath);
@@ -60,8 +60,8 @@ if(!fs.existsSync(paths.backstopConfigFileName)){
 
 // overwrite default filepaths if config files exist
 if(fs.existsSync(paths.activeCaptureConfigPath)){
-  var configJSON = fs.readFileSync(paths.activeCaptureConfigPath, "utf8");
-  var config = JSON.parse(configJSON);
+  var config = require(paths.activeCaptureConfigPath);
+
   if (config.paths) {
     paths.bitmaps_reference = config.paths.bitmaps_reference || paths.bitmaps_reference;
     paths.bitmaps_test = config.paths.bitmaps_test || paths.bitmaps_test;

--- a/test/configExample.js
+++ b/test/configExample.js
@@ -1,0 +1,51 @@
+// Example config using js rather than json.
+module.exports = {
+	// The viewports
+  "viewports": [
+    {
+      "name": "phone",
+      "width": 320,
+      "height": 480
+    },
+    {
+      "name": "tablet_v",
+      "width": 568,
+      "height": 1024
+    },
+    {
+      "name": "tablet_h",
+      "width": 1024,
+      "height": 768
+    }
+  ],
+
+	// Scenarios
+  "scenarios": [
+    {
+      "label": "measure twice",
+      "url": "test/simple.html",
+      "hideSelectors": [],
+      "removeSelectors": [
+        "#carbonads-container"
+      ],
+      "selectors": [
+        ".page-header h1",
+        ".page-header small",
+        ".graph:nth-of-type(1)",
+        ".graph:nth-of-type(2)",
+        "body",
+        "nav"
+      ],
+      "readyEvent": "backstop.ready",
+      "delay": 10,
+      "misMatchThreshold" : 0.1
+    }
+  ],
+  "paths": {
+    "bitmaps_reference": "../../backstop_data/bitmaps_reference",
+    "bitmaps_test": "../../backstop_data/bitmaps_test",
+    "compare_data": "../../backstop_data/bitmaps_test/compare.json"
+  },
+  "engine": "phantomjs",
+  "report": ["CLI"]
+};

--- a/test/util/paths_spec.js
+++ b/test/util/paths_spec.js
@@ -88,18 +88,4 @@ describe("setting the backstop.json location", function () {
 			assert.equal(err.message, 'Couldn\'t resolve backstop config file');
 		}
 	});
-
-	it('should throw an exception if the custom backstop location is not pointing to a .json file', function () {
-		var customBackstopConfigPath = '/backstop/config.txt';
-
-		mockery.registerMock('yargs', {
-			argv: {backstopConfigFilePath: customBackstopConfigPath}
-		});
-		try {
-			require('../../gulp/util/paths.js');
-			assert.fail();
-		} catch(err) {
-			assert.equal(err.message, 'Backstop config file has to be a .json file');
-		}
-	});
 });

--- a/test/util/paths_spec.js
+++ b/test/util/paths_spec.js
@@ -30,6 +30,8 @@ describe("setting the backstop.json location", function () {
 				return "{}";
 			}
 		});
+		// Mock require(expectedBackstopPath).
+		mockery.registerMock(expectedBackstopPath, {});
 		var paths = require('../../gulp/util/paths.js');
 		assert.equal(paths.activeCaptureConfigPath, expectedBackstopPath);
 	});

--- a/test/util/paths_spec.js
+++ b/test/util/paths_spec.js
@@ -48,6 +48,8 @@ describe("setting the backstop.json location", function () {
 				return "{}";
 			}
 		});
+		// Mock require(expectedBackstopPath).
+		mockery.registerMock(expectedBackstopPath, {});
 		var paths = require('../../gulp/util/paths.js');
 		assert.equal(paths.activeCaptureConfigPath, expectedBackstopPath);
 	});
@@ -66,6 +68,8 @@ describe("setting the backstop.json location", function () {
 				return "{}";
 			}
 		});
+		// Mock require(customBackstopConfigPath).
+		mockery.registerMock(customBackstopConfigPath, {});
 		var paths = require('../../gulp/util/paths.js');
 		assert.equal(paths.activeCaptureConfigPath, customBackstopConfigPath);
 	});


### PR DESCRIPTION
Feature wanted in https://github.com/garris/BackstopJS/issues/117

Must be used with --backstopConfigFilePath to use a json/js config file.