### PR TITLE
#124 uses checksum to detect config changes

### DIFF
--- a/capture/echoFiles.js
+++ b/capture/echoFiles.js
@@ -178,8 +178,11 @@ casper.run(function(){
 });
 
 function complete(){
-  var configData = JSON.stringify(compareConfig,null,2);
-  fs.write(compareConfigFileName, configData, 'w');
+  fs.touch(compareConfigFileName);
+  var compareConfigFile = fs.read(compareConfigFileName);
+  var compareConfigJSON = JSON.parse(compareConfigFile || '{}');
+  compareConfigJSON.compareConfig = compareConfig;
+  fs.write(compareConfigFileName, JSON.stringify(compareConfigJSON,null,2), 'w');
   console.log(
     '\n======================\nechoFiles has completed \n=======================\n'
     //,configData

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -245,9 +245,11 @@ casper.run(function(){
 });
 
 function complete(){
-  var configData = JSON.stringify(compareConfig,null,2);
   fs.touch(compareConfigFileName);
-  fs.write(compareConfigFileName, configData, 'w');
+  var compareConfigFile = fs.read(compareConfigFileName);
+  var compareConfigJSON = JSON.parse(compareConfigFile || '{}');
+  compareConfigJSON.compareConfig = compareConfig;
+  fs.write(compareConfigFileName, JSON.stringify(compareConfigJSON,null,2), 'w');
   console.log(
     'Comparison config file updated.'
     //,configData

--- a/gulp/tasks/bless.js
+++ b/gulp/tasks/bless.js
@@ -1,12 +1,13 @@
 var gulp   = require('gulp');
 var paths  = require('../util/paths');
-var rename = require("gulp-rename");
-
-
+var checksum = require('checksum');
+var fsx = require('fs-extra');
+var updateCompareConfigs = require('../util/updateCompareConfig');
 
 //BLESS THE CURRENT CAPTURE CONFIG
-gulp.task('bless',function(){
-  return gulp.src(paths.activeCaptureConfigPath)
-    .pipe(rename(paths.captureConfigFileNameCache))
-    .pipe(gulp.dest('/'));
+gulp.task('bless',function() {
+  var config = fsx.readFileSync(paths.activeCaptureConfigPath, 'utf8');
+  updateCompareConfigs(function(compareConfig) {
+      compareConfig.lastConfigHash = checksum(config);
+  });
 });

--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -7,7 +7,7 @@ var _ = require('underscore');
 
 
 gulp.task('compare', function (done) {
-  var compareConfig = JSON.parse(fs.readFileSync(paths.compareConfigFileName, 'utf8'));
+  var compareConfig = JSON.parse(fs.readFileSync(paths.compareConfigFileName, 'utf8')).compareConfig;
 
   function updateProgress() {
     var results = {};

--- a/gulp/tasks/openReport.js
+++ b/gulp/tasks/openReport.js
@@ -29,16 +29,15 @@ gulp.task("openReport", function(){
 
   gulp.src(paths.compareConfigFileName)
     .pipe(jeditor(function(json) {
-      json.testPairs.forEach(function(item){
+      json.compareConfig.testPairs.forEach(function(item){
         var rFile = referenceDir + item.reference.split('/').slice(-1)[0];
         var tFile = testDir + item.test.split('/').slice(-2).join('/');
         item.local_reference = rFile;
         item.local_test = tFile;
-      })
-      return json;
+      });
+      return json.compareConfig;
     }))
     .pipe(rename('compare/config.json'))
     .pipe(gulp.dest('.'))
     .pipe(open("",options));
-
 });

--- a/gulp/util/genDefaultCompareConfig.js
+++ b/gulp/util/genDefaultCompareConfig.js
@@ -1,14 +1,13 @@
-var fsx = require('fs-extra');
-var paths = require('./paths');
-
+var updateCompareConfigs = require('./updateCompareConfig');
 
 var configDefault = {
   "testPairs": []
 };
 
 var genDefaultCompareConfig = function () {
-  fsx.ensureFileSync(paths.compareConfigFileName);
-  fsx.writeFileSync(paths.compareConfigFileName, JSON.stringify(configDefault,null,2));
+  updateCompareConfigs(function(compareConfigFile) {
+    compareConfigFile.compareConfig = JSON.stringify(configDefault,null,2);
+  });
 };
 
 module.exports = genDefaultCompareConfig;

--- a/gulp/util/updateCompareConfig.js
+++ b/gulp/util/updateCompareConfig.js
@@ -1,0 +1,11 @@
+var paths = require('./paths');
+var fsx = require('fs-extra');
+
+var updateCompareConfig = function(updateCallback) {
+  fsx.ensureFileSync(paths.compareConfigFileName);
+  var compareConfigFile = fsx.readJsonSync(paths.compareConfigFileName, {throws: false}) || {};
+  updateCallback(compareConfigFile);
+  fsx.writeFileSync(paths.compareConfigFileName, JSON.stringify(compareConfigFile,null,2));
+};
+
+module.exports = updateCompareConfig;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mockery": "^1.4.0"
   },
   "dependencies": {
+    "checksum": "^0.1.1",
     "del": "^0.1.3",
     "express": "^3.8.1",
     "fs-extra": "^0.12.0",


### PR DESCRIPTION
* use npm's checksum to compute file checksums (uses sha1)
* introduces `compareConfig.lastConfigHash` to persist config checksum
* move content of `compareConfig` to `compareConfig.compareConfig`
* makes bless compute a checksum of the config and adding it to the
compareConfigFile as `lastConfigHash`