### PR TITLE
Separate creating browser report data from starting server and launching browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,9 @@ _**NOTE:** SlimerJS currently requires an absolute path -- so be sure to include
 
 
 ### Reporting workflow tips (version 0.7.0+)
-There are two reporting options.  The fastest and least obtrusive is the CLI report which gives you a subdued thumbs up or thumbs down for your layout on each run.  The other report runs in the in-browser -- this gives you detailed visual feedback for each test case so you can validate why your screen diffs score the way they do.
+There are two types of reports. The fastest and least obtrusive is the CLI report which gives you a subdued thumbs up or thumbs down for your layout on each run.  The other report, displayed in the browser, gives you detailed visual feedback for each test case so you can validate why your screen diffs score the way they do.
 
-One testing approach to consider is incorporating BackstopJS into your build process and just let the CLI report run on each build.  It's natural for your layout to break while you're in feature development -- refer back to the report when you feel things should be shaping up. Check the in-browser version of the report occasionally as needed when you need deeper information about what's happening in a test case.
+One testing approach to consider is incorporating BackstopJS into your build process and just let the CLI report run on each build. It's natural for your layout to break while you're in feature development -- refer back to the report when you feel things should be shaping up. Check the in-browser version of the report occasionally as needed when you need deeper information about what's happening in a test case.
 
 _CLI Report_
 
@@ -440,6 +440,11 @@ Using the report property in `backstop.json` enable or disable browser or server
 ```json
 "report": ["browser", "CLI"]
 ```
+
+There are three different report options:
+- `CLI` displays test results in the console.
+- `browser` prepares the test data, starts a server, and opens the report in the browser.
+- `prepare` only prepares the test data for the html report. (This is useful if you are running headless and/or would like to view the html report through an alternate server you are running separately.)
 
 If you choose the CLI-only reporting you can always enter the following command to see the latest test run report in the browser.
 

--- a/gulp/tasks/createReport.js
+++ b/gulp/tasks/createReport.js
@@ -1,0 +1,35 @@
+var gulp  = require('gulp');
+var paths = require('../util/paths');
+var rename = require('gulp-rename');
+var jeditor = require("gulp-json-editor");
+
+var referenceDir = './bitmaps_reference/';
+var testDir = './bitmaps_test/';
+
+gulp.task("createReport", function(){
+
+  console.log('\nTesting with ',paths.compareConfigFileName);
+  console.log('Creating report -> ',paths.compareReportURL + '\n');
+
+  // cache bitmaps_reference files locally
+  gulp.src(paths.bitmaps_reference + '/**/*')
+    .pipe(gulp.dest(referenceDir));
+
+  // cache bitmaps_test files locally
+  gulp.src(paths.bitmaps_test + '/**/*')
+    .pipe(gulp.dest(testDir));
+
+
+  gulp.src(paths.compareConfigFileName)
+    .pipe(jeditor(function(json) {
+      json.compareConfig.testPairs.forEach(function(item){
+        var rFile = referenceDir + item.reference.split('/').slice(-1)[0];
+        var tFile = testDir + item.test.split('/').slice(-2).join('/');
+        item.local_reference = rFile;
+        item.local_test = tFile;
+      });
+      return json.compareConfig;
+    }))
+    .pipe(rename('compare/config.json'))
+    .pipe(gulp.dest('.'));
+});

--- a/gulp/tasks/openReport.js
+++ b/gulp/tasks/openReport.js
@@ -2,13 +2,11 @@ var gulp  = require('gulp');
 var open  = require("gulp-open");
 var isWin = require('../util/isWin');
 var paths = require('../util/paths');
-var rename = require('gulp-rename');
-var jeditor = require("gulp-json-editor");
 
 var referenceDir = './bitmaps_reference/';
 var testDir = './bitmaps_test/';
 
-gulp.task("openReport", function(){
+gulp.task("openReport", ['start', 'createReport'], function(){
 
   console.log('\nTesting with ',paths.compareConfigFileName);
   console.log('Opening report -> ',paths.compareReportURL + '\n');
@@ -18,26 +16,6 @@ gulp.task("openReport", function(){
     ,app: isWin ? "chrome" : "Google Chrome"
   };
 
-  // cache bitmaps_reference files locally
-  gulp.src(paths.bitmaps_reference + '/**/*')
-    .pipe(gulp.dest(referenceDir));
+  gulp.src(paths.compareConfigFileName).pipe(open("",options));
 
-  // cache bitmaps_test files locally
-  gulp.src(paths.bitmaps_test + '/**/*')
-    .pipe(gulp.dest(testDir));
-
-
-  gulp.src(paths.compareConfigFileName)
-    .pipe(jeditor(function(json) {
-      json.compareConfig.testPairs.forEach(function(item){
-        var rFile = referenceDir + item.reference.split('/').slice(-1)[0];
-        var tFile = testDir + item.test.split('/').slice(-2).join('/');
-        item.local_reference = rFile;
-        item.local_test = tFile;
-      });
-      return json.compareConfig;
-    }))
-    .pipe(rename('compare/config.json'))
-    .pipe(gulp.dest('.'))
-    .pipe(open("",options));
 });

--- a/gulp/tasks/report.js
+++ b/gulp/tasks/report.js
@@ -1,10 +1,14 @@
 var gulp = require('gulp');
 var paths = require('../util/paths');
 
-gulp.task('report',['start'],function(){
+gulp.task('report', function(){
 
   if (!paths.report || paths.report.indexOf( 'browser' ) > -1 ){
     setTimeout(function(){gulp.run('openReport')},100);
+  }
+
+  if (!paths.report || paths.report.indexOf( 'prepare' ) > -1 ){
+    setTimeout(function(){gulp.run('createReport')},100);
   }
 
   if (!paths.report || paths.report.indexOf( 'CLI' ) > -1 ){


### PR DESCRIPTION
This PR...
- separates into two tasks creating browser report data and the launching of the server/browser.
- creates a report option to only create report data.
- maintains backwards compatibility, so all commands continue to work as expected.
- updates documentation.
- only starts the server when the browser will be opened. (It appears that previously the server would start even when only the CLI report was being run.)

Use case: running headless on a local/dev server to prepare reports that can be seen later through the dev server's already running apache/nginx server. I'm thinking about setting up a Jenkins job to automatically run a backstop test overnight that can be viewed by QA team and devs each morning.

