### PR TITLE
Use flexbox to size column widths on the BackstopJS report

### DIFF
--- a/compare/css/styles.css
+++ b/compare/css/styles.css
@@ -7,8 +7,25 @@ td img{width: 100%;}
 table{width: 100%;border-collapse: collapse;margin-bottom: 50px;}
 input{width: 55ex; display: none;}
 th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
-th.selector,th.filename{background-color: #666;color:#fff;}
-th.filename{text-align: right;}
+
+.results {
+  margin-bottom: 20px;
+}
+.flex-container {
+  display: flex;
+  margin-bottom: 10px;
+}
+.flex-container > div {
+  flex: 1;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.flex-container > div img {
+  max-width: 100%;
+}
+.flex-container .selector,.flex-container .filename{background-color: #666;color:#fff; padding: 5px;}
+.flex-container .filename{text-align: right; padding: 5px;}
+
 .reportTxt{white-space: pre-wrap;font-family: monospace; font-size: 11px;}
 .summaryList{padding: 0px;list-style: none;width: auto;}
 .summaryList td{width: auto; padding: 5px;}

--- a/compare/index.html
+++ b/compare/index.html
@@ -52,30 +52,28 @@
 
       </div>
 
-      <table ng-repeat="thisTestPair in testPairs | filter : displayOnStatusFilter ">
-        <thead>
-          <tr>
-            <th class="selector" colspan="2">{{ thisTestPair.meta.label }} {{ thisTestPair.meta.selector }}</th>
-            <th class="filename" colspan="2">{{ thisTestPair.meta.fileName }}</th>
-          </tr>
-          <tr>
-            <th>Reference</th>
-            <th>Test</th>
-            <th>Diff</th>
-            <th>Report</th>
-          </tr>
-        </thead>
-        <tr>
-          <td>
+      <div class="results" ng-repeat="thisTestPair in testPairs | filter : displayOnStatusFilter">
+        <div class="flex-container">
+            <div class="selector">{{ thisTestPair.meta.label }} {{ thisTestPair.meta.selector }}</div>
+            <div class="filename">{{ thisTestPair.meta.fileName }}</div>
+        </div>
+        <div class="flex-container">
+            <div>Reference</div>
+            <div>Test</div>
+            <div>Diff</div>
+            <div>Report</div>
+        </div>
+        <div class="flex-container">
+          <div>
             <img ng-src="{{ thisTestPair.a.src }}">
-          </td>
-          <td>
+          </div>
+          <div>
             <img ng-src="{{ thisTestPair.b.src }}">
-          </td>
-          <td>
+          </div>
+          <div>
             <img ng-src="{{ thisTestPair.c.src }}" image-name="c">
-          </td>
-          <td>
+          </div>
+          <div>
             <div class="statusInds">
               <div class="indicator scanning" ng-if="thisTestPair.processing"><span class="dot yellow flash"></span>scanning</div>
               <div class="indicator failed" ng-if="!thisTestPair.passed&&!thisTestPair.processing"><span class="dot red"></span>failed</div>
@@ -83,10 +81,9 @@
             </div>
             <div class="reportTxt">Threshold: {{ thisTestPair.meta.misMatchThreshold}}</div>
             <div class="reportTxt">Report: {{ thisTestPair.report }}</div>
-          </td>
-        </tr>
-      </table>
-
+          </div>
+        </div>
+      </div>
 
     </div> <!-- end detailReport -->
 


### PR DESCRIPTION
Use flexbox to size column widths on the BackstopJS report.

Previously, using a table with 4 columns at 25% width didn't always results in equal columns.

This meant that the diff image would not necessarily line up with the reference and test images meaning it was difficult on long pages to easily eyeball the identified differences with the reference and test images.

Using flexbox means that we can guarantee that the columns will be of equal width, and hence the images will line up properly.
