### PR TITLE
Fix flexbox display for Firefox

### DIFF
--- a/compare/css/styles.css
+++ b/compare/css/styles.css
@@ -19,6 +19,7 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
   flex: 1;
   padding-left: 5px;
   padding-right: 5px;
+  min-width: 1px; /* for Firefox */
 }
 .flex-container > div img {
   max-width: 100%;


### PR DESCRIPTION
This pull request fixes a small problem with flexbox display in Firefox, whereby large images are not constrained to their container correctly.

Tested on the latest release of all major browsers (Edge 13, IE 11, FF 46, Chrome 49).

Note that Flexbox support is pretty good these days, but IE9 and before are not supported:
http://caniuse.com/#feat=flexbox