### PR TITLE
prevent clipping when using "body" selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,11 @@ From `./node_modules/backstopjs` ...
 $ gulp echo
 ```
 
+#### Body capture is clipped  
+
+Some stylesheets include a `height:100%` rule on the `<body>` element. When you use the `body` selector in this scenario, the resulting image will be clipped to the viewport. A special `body:noclip` selector is availble to force casper to use `casper.capture()` instead of `casper.captureSelector()`. Simply replace any `body` selectors in your scenarios config with `body:noclip` and this should ensure that the entire document is captured.
+
+
 ### Running the report server
 
 The test comparison report was written in Angular.js and requires a running HTTP server instance.  This instance is auto-started after a test is run.  The server is also auto-stopped after 15 minutes so you don't have to go worrying about node processes running all over the place.

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -172,7 +172,12 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
 
           if (casper.exists(o)) {
             if (casper.visible(o)) {
-              casper.captureSelector(filePath, o);
+              if(o=="body") {
+                casper.capture(filePath);
+              }
+              else {
+                casper.captureSelector(filePath, o);
+              }
             } else {
               var assetData = fs.read(hiddenSelectorPath, 'b');
               fs.write(filePath, assetData, 'b');

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -170,14 +170,11 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
           var filePath      = (isReference)?reference_FP:test_FP;
 
 
-          if (casper.exists(o)) {
+          if(o === "body:noclip") {
+            casper.capture(filePath);
+          } else if (casper.exists(o)) {
             if (casper.visible(o)) {
-              if(o=="body") {
-                casper.capture(filePath);
-              }
-              else {
-                casper.captureSelector(filePath, o);
-              }
+              casper.captureSelector(filePath, o);
             } else {
               var assetData = fs.read(hiddenSelectorPath, 'b');
               fs.write(filePath, assetData, 'b');


### PR DESCRIPTION
When using a "body" selector, the capture is clipped to the area of the viewport.

Using `casper.capture()` you can capture the entire document regardless of size.

