### PR TITLE
adding JUnit report generation functionality

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -4,66 +4,86 @@ var paths = require('../util/paths');
 var fs = require('fs');
 var path = require('path');
 var _ = require('underscore');
-
+var junitWriter = new (require('junitwriter'))();
 
 gulp.task('compare', function (done) {
-  var compareConfig = JSON.parse(fs.readFileSync(paths.compareConfigFileName, 'utf8')).compareConfig;
+    var compareConfig = JSON.parse(fs.readFileSync(paths.compareConfigFileName, 'utf8')).compareConfig,
+    testSuite = paths.report && paths.report.indexOf( 'CI' ) > -1 && paths.ciReport.format === 'junit' && junitWriter.addTestsuite(paths.ci.testSuiteName),
+    testPairsLength;
 
-  function updateProgress() {
-    var results = {};
-    _.each(compareConfig.testPairs, function (pair) {
-      if (!results[pair.testStatus]) {
-        results[pair.testStatus] = 0;
-      }
-      !results[pair.testStatus]++;
-    });
-    if (!results.running) {
-      console.log ('\nTest completed...');
-      console.log ('\x1b[32m', (results.pass || 0) + ' Passed', '\x1b[0m');
-      console.log ('\x1b[31m', (results.fail || 0) + ' Failed\n', '\x1b[0m');
+    function updateProgress() {
+        var results = {};
+        _.each(compareConfig.testPairs, function (pair) {
+            if (!results[pair.testStatus]) {
+                results[pair.testStatus] = 0;
+            }
+            !results[pair.testStatus]++;
+        });
+        if (!results.running) {
+            console.log ('\nTest completed...');
+            console.log ('\x1b[32m', (results.pass || 0) + ' Passed', '\x1b[0m');
+            console.log ('\x1b[31m', (results.fail || 0) + ' Failed\n', '\x1b[0m');
 
-      if (results.fail) {
-        console.log ('\x1b[31m', '*** Mismatch errors found ***', '\x1b[0m');
-        console.log ("For a detailed report run `npm run openReport`\n");
-        done(new Error('Mismatch errors found.'));
-      } else {
-        done();
-      }
-
+            if (results.fail) {
+                console.log ('\x1b[31m', '*** Mismatch errors found ***', '\x1b[0m');
+                console.log ("For a detailed report run `npm run openReport`\n");
+                if (paths.cliExitOnFail) {
+                    done(new Error('Mismatch errors found.'));
+                }
+            }
+        }
     }
-  }
 
 
-  _.each(compareConfig.testPairs, function (pair) {
-    pair.testStatus = "running";
+    _.each(compareConfig.testPairs, function (pair, key) {
+        pair.testStatus = "running";
+        testPairsLength = !testPairsLength && compareConfig.testPairs.length;
 
-    var referencePath = path.join(paths.backstop, pair.reference);
-    var testPath = path.join(paths.backstop, pair.test);
 
-    resemble(referencePath).compareTo(testPath).onComplete(function (data) {
-      var imageComparisonFailed = !data.isSameDimensions || data.misMatchPercentage > pair.misMatchThreshold;
+        var referencePath = path.join(paths.backstop, pair.reference);
+        var testPath = path.join(paths.backstop, pair.test);
 
-      if (imageComparisonFailed) {
-        pair.testStatus = "fail";
-        console.log('\x1b[31m', 'ERROR:', pair.label, pair.fileName, '\x1b[0m');
-        storeFailedDiffImage(testPath, data);
-      } else {
-        pair.testStatus = "pass";
-        console.log('\x1b[32m', 'OK:', pair.label, pair.fileName, '\x1b[0m');
-      }
-      updateProgress();
+        resemble(referencePath).compareTo(testPath).onComplete(function (data) {
+            var imageComparisonFailed = !data.isSameDimensions || data.misMatchPercentage > pair.misMatchThreshold,
+            error,
+            testCase;
+
+            if (imageComparisonFailed) {
+                pair.testStatus = "fail";
+                console.log('\x1b[31m', 'ERROR:', pair.label, pair.fileName, '\x1b[0m');
+                storeFailedDiffImage(testPath, data);
+            } else {
+                pair.testStatus = "pass";
+                console.log('\x1b[32m', 'OK:', pair.label, pair.fileName, '\x1b[0m');
+            }
+
+            // add testcase only when there is a design deviation
+            if (testSuite && imageComparisonFailed) {
+                testCase = testSuite.addTestcase(' ›› ' + pair.label, pair.selector);
+                error = 'Design deviation ›› ' + pair.label + ' (' + pair.selector + ') component';
+                testCase.addError(error, 'CSS component');
+                testCase.addFailure(error, 'CSS component');
+            }
+
+            if (testSuite && testPairsLength === key + 1) {
+                junitWriter.save(path.join(paths.ci_report, 'xunit.xml'), function() {
+                    console.log('\x1b[32m', 'Regression test report file (xunit.xml) is successfully created.', '\x1b[0m');
+                });
+            }
+
+            updateProgress();
+        });
     });
-  });
 
-  function storeFailedDiffImage(testPath, data) {
-    var failedDiffFilename = getFailedDiffFilename(testPath);
-    console.log('   See:', failedDiffFilename);
-    var failedDiffStream = fs.createWriteStream(failedDiffFilename);
-    data.getDiffImage().pack().pipe(failedDiffStream)
-  }
+    function storeFailedDiffImage(testPath, data) {
+        var failedDiffFilename = getFailedDiffFilename(testPath);
+        console.log('   See:', failedDiffFilename);
+        var failedDiffStream = fs.createWriteStream(failedDiffFilename);
+        data.getDiffImage().pack().pipe(failedDiffStream)
+    }
 
-  function getFailedDiffFilename(testPath) {
-    var lastSlash = testPath.lastIndexOf(path.sep);
-    return testPath.slice(0, lastSlash + 1) + 'failed_diff_' + testPath.slice(lastSlash + 1, testPath.length);
-  }
+    function getFailedDiffFilename(testPath) {
+        var lastSlash = testPath.lastIndexOf(path.sep);
+        return testPath.slice(0, lastSlash + 1) + 'failed_diff_' + testPath.slice(lastSlash + 1, testPath.length);
+    }
 });

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -7,6 +7,10 @@ var defaultConfigPath = '../../backstop.json';
 
 var paths = {};
 paths.portNumber = defaultPort;
+paths.ci = {
+    format: 'junit',
+    testSuiteName: 'BackstopJS'
+};
 
 // BACKSTOP MODULE PATH
 paths.backstop                      = path.join(__dirname, '../..');
@@ -29,6 +33,9 @@ paths.backstopConfigFileName = getBackstopConfigFileName();
 // BITMAPS PATHS -- note: this path is overwritten if config files exist.  see below.
 paths.bitmaps_reference             = paths.backstop + '/bitmaps_reference';
 paths.bitmaps_test                  = paths.backstop + '/bitmaps_test';
+
+// Continuous Integration (CI) report
+paths.ci_report                     = paths.backstop + '/ci_report';
 
 // COMPARE PATHS -- note: compareConfigFileName is overwritten if config files exist.  see below.
 paths.comparePath                   = paths.backstop + '/compare';
@@ -66,12 +73,14 @@ if(fs.existsSync(paths.activeCaptureConfigPath)){
     paths.bitmaps_test = config.paths.bitmaps_test || paths.bitmaps_test;
     paths.compareConfigFileName = config.paths.compare_data || paths.compareConfigFileName;
     paths.casper_scripts = config.paths.casper_scripts || null;
+    paths.ci_report = config.paths.ci_report || paths.ci_report;
   }
 
   paths.portNumber = config.port || defaultPort;
   paths.casperFlags = config.casperFlags || null;
   paths.engine = config.engine || null;
   paths.report = config.report || null;
+  paths.ciReport = config.ci || paths.ci;
 }
 
 paths.compareReportURL = 'http://localhost:' + paths.portNumber + '/compare/';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "BackstopJS: Catch CSS curveballs.",
   "scripts": {
     "genConfig": "gulp genConfig",
@@ -37,6 +37,7 @@
     "gulp-json-editor": "^2.2.1",
     "gulp-open": "^0.3.0",
     "gulp-rename": "^1.2.0",
+    "junitwriter" : "~0.3.1" ,
     "http-proxy": "~1.1.4",
     "is-running": "~1.0.5",
     "node-resemble-js": "0.0.4",


### PR DESCRIPTION
The regression test report will be generated in the JUnit format and report will be placed in the given directory (default: _[backstopjs dir]/test/ci_report/xunit.xml_).

The following config would enable the CI - report (default: junit format)
```
report : [ CLI ,  CI ],
```

The following optional config would override the default config
```
 paths : {
       bitmaps_reference :  ../../tests/bitmaps_reference ,
       bitmaps_test :  ../../tests/bitmaps_test ,
       compare_data :  ../../tests/bitmaps_reference/compare.json ,
~      casper_scripts :  ../../tests/casper_scripts ,
+      ci_report :  ../../tests/ci_report
+   },
+    ci : {
+      format :  junit ,
+      testSuiteName :  backstopJS
+
    },
```