### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can add BackstopJS from the root directory of any project.
 $ npm install --save-dev backstopjs
 ```
 
-###Installing a develpment version
+###Installing a development version
 
 ```sh
 $ npm install garris/backstopjs#master
@@ -352,7 +352,7 @@ Inside `filename.js`, structure it like this:
 module.exports = function(casper, scenario, vp) {
   // scenario is the current scenario object being run from your backstop config
   // vp is the current viewport object being run from your backstop config
-  
+
   // Example: setting cookies
   casper.echo("Setting cookies");
   casper.then(function(){
@@ -361,17 +361,17 @@ module.exports = function(casper, scenario, vp) {
   // `casper.thenOpen()` demonstrates a redirect to the original page with your new cookie value.
   // this step is not required if used with _onBeforeScript_
   casper.thenOpen(scenario.url);
-  
+
   // Example: Adding script delays to allow for things like CSS transitions to complete.
   casper.echo( 'Clicking button' );
   casper.click( '.toggle' );
   casper.wait( 250 );
-  
+
   // Example: changing behaivior based on config values
   if (vp.name === 'phone') {
     casper.echo( 'doing stuff for just phone viewport here' );
   }
-  
+
   // ...do other cool stuff here, see Casperjs.org for a full API and many ideas.
 }
 ```


### PR DESCRIPTION
I don't know why PHPStorm removed the spaces in the empty lines :/