### PR TITLE
custom testSuiteName fix

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -8,7 +8,7 @@ var junitWriter = new (require('junitwriter'))();
 
 gulp.task('compare', function (done) {
     var compareConfig = JSON.parse(fs.readFileSync(paths.compareConfigFileName, 'utf8')).compareConfig,
-    testSuite = paths.report && paths.report.indexOf( 'CI' ) > -1 && paths.ciReport.format === 'junit' && junitWriter.addTestsuite(paths.ci.testSuiteName),
+    testSuite = paths.report && paths.report.indexOf( 'CI' ) > -1 && paths.ciReport.format === 'junit' && junitWriter.addTestsuite(paths.ciReport.testSuiteName),
     testPairsLength;
 
     function updateProgress() {


### PR DESCRIPTION
The custom testSuiteName does not work and it's always taking the default name which is 'BackstopJS'. This would fix and make it work as expected.