### PR TITLE
fixing the CI report for mutiple CSS selectors

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -37,7 +37,10 @@ gulp.task('compare', function (done) {
 
     _.each(compareConfig.testPairs, function (pair, key) {
         pair.testStatus = "running";
-        testPairsLength = !testPairsLength && compareConfig.testPairs.length;
+
+        if (!testPairsLength) {
+            testPairsLength = Object.keys(compareConfig.testPairs).length;
+        }
 
 
         var referencePath = path.join(paths.backstop, pair.reference);


### PR DESCRIPTION
The ```compareConfig.testPairs``` would always be an Object and not an Array. This would fix the https://github.com/garris/BackstopJS/issues/210