### PR TITLE
Exit code 1 on fail

### DIFF
--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -27,9 +27,7 @@ gulp.task('compare', function (done) {
             if (results.fail) {
                 console.log ('\x1b[31m', '*** Mismatch errors found ***', '\x1b[0m');
                 console.log ("For a detailed report run `npm run openReport`\n");
-                if (paths.cliExitOnFail) {
-                    done(new Error('Mismatch errors found.'));
-                }
+                done(new Error('Mismatch errors found.'));
             }
         }
     }

--- a/test/simpleReactApp/backstop.json
+++ b/test/simpleReactApp/backstop.json
@@ -41,7 +41,6 @@
   },
   "engine": "phantomjs",
   "report": ["CLI", "browser"],
-  "cliExitOnFail": false,
   "casperFlags": [],
   "debug": false,
   "port": 3001


### PR DESCRIPTION
Fixes #135.  This PR removes the `cliExitOnFail` option, always exiting code 1 on fail instead:

## Failure Example

Exit code is `0`.

```sh
$ npm run test

...

Test completed...
 0 Passed
 45 Failed

 *** Mismatch errors found ***
For a detailed report run `npm run openReport`

[10:48:37] 'compare' errored after 21 s
[10:48:37] Error: Mismatch errors found.
    at updateProgress (XXX/node_modules/backstopjs/gulp/tasks/compare.js:30:22)
    at Array.<anonymous> (XXX/node_modules/backstopjs/gulp/tasks/compare.js:76:13)
    at triggerDataUpdate (XXX/node_modules/node-resemble-js/resemble.js:69:28)
    at onceWeHaveBoth (XXX/node_modules/node-resemble-js/resemble.js:447:6)
    at .<anonymous> (XXX/node_modules/node-resemble-js/resemble.js:125:13)
    at emitOne (events.js:96:13)
    at emit (events.js:188:7)
    at .<anonymous> (XXX/node_modules/pngjs/lib/png.js:52:14)
    at emitOne (events.js:96:13)
    at emit (events.js:188:7)

$ echo $?
1
```

## Passing Example

Exit code is `1`.

```sh
$ npm run test

...

Test completed...
 45 Passed
 0 Failed

$ echo $?
0
```
