### PR TITLE
Fix referenceUrl bug when using onBeforeScript

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -75,10 +75,10 @@ function capturePageSelectors(url,scenarios,viewports,bitmaps_reference,bitmaps_
         this.viewport(vp.width||vp.viewport.width, vp.height||vp.viewport.height);
       });
 
-      var url = scenario.url;
       if (isReference && scenario.referenceUrl) {
-        url = scenario.referenceUrl;
+        scenario.url = scenario.referenceUrl;
       }
+      var url = scenario.url;
 
       var onBeforeScript = scenario.onBeforeScript || config.onBeforeScript;
       if (onBeforeScript) {


### PR DESCRIPTION
Previously, if you use referenceUrl which differs from url. the scenario.url object is still using url. 
in the case below with an onBeforeScript to login: `capser.thenOpen(scenario.url)` will ignore the referenceURL and still use the test url. 

    // EXAMPLE: LOGIN BEFORE RUNNING TESTS
    module.exports = function(casper, scenario, vp) {
      casper.thenOpen(scenario.url, function(){
         if (this.exists('form#user-login-form')) {
           this.fill('form#loginForm',{
              'username': 'test',
              'password': 'changeme'
           }, true);
         }
      });
    };