### PR TITLE
Custom Test Report filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,12 +362,13 @@ The regression test report will be generated in the JUnit format and the report 
 
 You may customize the testsuite name and/or a report file (xunit.xml) path to your build report directory by using the below configuration overrides,
 
-```json
+```js
 "paths": {
        "ci_report" :  "../../backstop_data/ci_report"
 },
 "ci": {
       "format" :  "junit" ,
+      "testReportFileName": "myproject-xunit", // in case if you want to override the default filename (xunit.xml)
       "testSuiteName" :  "backstopJS"
 },
 ```
@@ -591,7 +592,7 @@ BackstopJS was created by [Garris Shipon](expanded.me) during the [Art.com labs]
 ...
 
 ## Many many thanks to [all the contributors](https://github.com/garris/BackstopJS/graphs/contributors) with special thanks to...
-- [Shuresh KM](https://github.com/garris/BackstopJS/commits/master?author=nobso) for help on the 1.3.2 release
+- [Suresh Kumar. M](https://github.com/garris/BackstopJS/commits/master?author=nobso) for help on the 1.3.2 release
 - [Klaus Bayrhammer](https://github.com/klausbayrhammer) for all the incredible effort leading up to 1.0 -- the cli reports and compatibility fixes are awesome!
 - [Evan Lovely](https://github.com/EvanLovely) and [Klaus Bayrhammer](https://github.com/klausbayrhammer) for help on the 0.9.0 release
 - [Robert O'Rourke](https://github.com/sanchothefat) for help on the 0.8.0 release

--- a/gulp/tasks/compare.js
+++ b/gulp/tasks/compare.js
@@ -12,7 +12,9 @@ gulp.task('compare', function (done) {
     testPairsLength;
 
     function updateProgress() {
-        var results = {};
+        var results = {},
+            testReportFileName;
+
         _.each(compareConfig.testPairs, function (pair) {
             if (!results[pair.testStatus]) {
                 results[pair.testStatus] = 0;
@@ -26,8 +28,9 @@ gulp.task('compare', function (done) {
 
             // if the test report is enabled in the config
             if (testSuite) {
-                junitWriter.save(path.join(paths.ci_report, 'xunit.xml'), function() {
-                    console.log('\x1b[32m', 'Regression test report file (xunit.xml) is successfully created.', '\x1b[0m');
+                testReportFileName = paths.ciReport.testReportFileName.replace(/(\..+)?$/, '.xml');
+                junitWriter.save(path.join(paths.ci_report, testReportFileName), function() {
+                    console.log('\x1b[32m', 'Regression test report file (' + testReportFileName + ') is successfully created.', '\x1b[0m');
                 });
             }
 
@@ -53,8 +56,8 @@ gulp.task('compare', function (done) {
 
         resemble(referencePath).compareTo(testPath).onComplete(function (data) {
             var imageComparisonFailed = !data.isSameDimensions || data.misMatchPercentage > pair.misMatchThreshold,
-            error,
-            testCase;
+                error,
+                testCase;
 
             if (imageComparisonFailed) {
                 pair.testStatus = "fail";

--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -9,6 +9,7 @@ var paths = {};
 paths.portNumber = defaultPort;
 paths.ci = {
     format: 'junit',
+    testReportFileName: 'xunit',
     testSuiteName: 'BackstopJS'
 };
 
@@ -80,7 +81,11 @@ if(fs.existsSync(paths.activeCaptureConfigPath)){
   paths.casperFlags = config.casperFlags || null;
   paths.engine = config.engine || null;
   paths.report = config.report || null;
-  paths.ciReport = config.ci || paths.ci;
+  paths.ciReport = config.ci ? {
+    format: config.ci.format || paths.ci.format,
+    testReportFileName: config.ci.testReportFileName || paths.ci.testReportFileName,
+    testSuiteName: config.ci.testSuiteName || paths.ci.testSuiteName
+  } : paths.ci;
 }
 
 paths.compareReportURL = 'http://localhost:' + paths.portNumber + '/compare/';


### PR DESCRIPTION
If there are other test files in the same build test directory, this common name (xunit.xml) may conflict with others. So lets give an option to customize the test report filename. 