### PR TITLE
Use of `npm explore` to run `backstopjs` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ $ npm install garris/backstopjs#master
 
 **If you don't already have a BackstopJS config file.** The following command will create a config template file which you can modify in your root directory. *Note: this will overwrite any existing backstopjs config file.*
 
-From `./node_modules/backstopjs` ...
-
 ```sh
-$ npm run genConfig
+$ npm explore backstopjs -- npm run genConfig
 ```
 
 
@@ -505,10 +503,8 @@ For a sanity check you can also use the following command -- it will output your
 
 _Please note: this will check your scenario `url` only.  It does not check for a `referenceUrl` property._
 
-From `./node_modules/backstopjs` ...
-
 ```sh
-$ npm run echo
+$ npm explore backstopjs -- npm run echo
 ```
 
 <!-- #### Body capture is clipped
@@ -522,16 +518,14 @@ The test comparison report was written in Angular.js and requires a running HTTP
 
 You can manually start the server optionally passing your own timeout parameter (in minutes). Passing 0 will disable the timeout feature and run the server until you manually stop it.
 
-From `./node_modules/backstopjs` ...
-
 ```sh
-$ npm run start -- -t 0
+$ npm explore backstopjs -- npm run start -- -t 0
 ```
 
-To manually stop the server, from `./node_modules/backstopjs` ...
+To manually stop the server ...
 
 ```sh
-$ npm run stop
+$ npm explore backstopjs -- npm run stop
 ```
 
 ---


### PR DESCRIPTION
From the docs (https://docs.npmjs.com/cli/explore):

> Spawn a subshell in the directory of the installed package specified.
> If a command is specified, then it is run in the subshell, which then immediately terminates.