### PR TITLE
support config opening report domain url

### DIFF
--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -88,6 +88,7 @@ if(fs.existsSync(paths.activeCaptureConfigPath)){
   } : paths.ci;
 }
 
-paths.compareReportURL = 'http://localhost:' + paths.portNumber + '/compare/';
+paths.domainUrl = argv.domainUrl ? (argv.domainUrl + ':') : 'http://localhost:';
+paths.compareReportURL = paths.domainUrl + paths.portNumber + '/compare/';
 
 module.exports = paths;


### PR DESCRIPTION
When i installed BackstopJs in my linux server, i want to usr my linux server domain url as the report url so that when i click the console output, i can directly redirect to the compare server.
