### PR TITLE
one-to-many selector testing capability is added [Fixes #245]

### DIFF
--- a/test/selectorExpansion/backstop.json
+++ b/test/selectorExpansion/backstop.json
@@ -1,0 +1,43 @@
+{
+  "viewports": [
+    {
+      "name": "phone",
+      "width": 320,
+      "height": 480
+    },
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 900
+    }
+  ],
+  "scenarios": [
+    {
+      "label": "primary buttons",
+      "url": "index.html",
+      "hideSelectors": [],
+      "removeSelectors": [
+        ".container .btn.btn-primary.anyclassname"
+      ],
+      "selectors": [
+        ".container  .btn.btn-primary"
+      ],
+      "enableSelectorExpansion": true,
+      "delay": 100,
+      "misMatchThreshold" : 0.1,
+      "onBeforeScript": "onBefore.js",
+      "onReadyScript": "onReady.js"
+    }
+  ],
+  "paths": {
+    "bitmaps_reference": "../../backstop_data/bitmaps_reference",
+    "bitmaps_test": "../../backstop_data/bitmaps_test",
+    "compare_data": "../../backstop_data/bitmaps_test/compare.json",
+    "casper_scripts": "../../backstop_data/casper_scripts"
+  },
+  "engine": "phantomjs",
+  "report": ["CLI", "browser"],
+  "casperFlags": [],
+  "debug": false,
+  "port": 3001
+}

--- a/test/selectorExpansion/index.html
+++ b/test/selectorExpansion/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="">
+        <meta name="author" content="">
+        <title>selectorExpansion - backstopJS</title>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    </head>
+    <body>
+        <div class="container">
+            <div class="starter-template">
+                <h1>Example: selector expansion</h1>
+                <p class="lead">There are 3 buttons with the same CSS classname (.btn-primary). If you want your test script to expand and test all the similar CSS components (.btn-primary), just use <code>enableSelectorExpansion: true</code> in the backstop config as mentioned in the example config file.</p>
+                <input class="btn btn-primary" type="submit" value="Submit">
+                <input class="btn btn-primary anyclassname" type="submit" value="Submit">
+                <input class="btn btn-primary" type="submit" value="Submit">
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
In the current version, there is only one-to-one selector testing can be done. All other similar selector elements are ignored after the first match.

This PR will add the capability to run tests on many similar selectors against one reference screenshot. 

This is not a configuration driven feature but we can make it if needed.

@garris what do you think of this? Please leave your comments if you have any.
