### PR TITLE
Add support for casper --xunit flag

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -237,6 +237,21 @@ function complete(){
   var compareConfigJSON = JSON.parse(compareConfigFile || '{}');
   compareConfigJSON.compareConfig = compareConfig;
   fs.write(compareConfigFileName, JSON.stringify(compareConfigJSON,null,2), 'w');
+
+  // Generate the xunit file if requested via a casper flag in the config.
+  var xunitFile;
+  if (config.casperFlags) {
+    config.casperFlags.forEach(function(casperFlag){
+      if (! xunitFile && casperFlag.match(/--xunit=(.*)$/)) {
+          xunitFile = casperFlag.match(/--xunit=(.*)$/)[1];
+      }
+    });
+  }
+
+  if (xunitFile) {
+    casper.test.renderResults(true, 0, xunitFile);
+  }
+
   console.log(
     'Comparison config file updated.'
     //,configData


### PR DESCRIPTION
We notice that, when specifying the xunit flag for casperjs, e.g.

```js
"casperFlags": ["--xunit=../../backstop_data/ci_report/xunit.casper.xml"],
```

the xunit report is not produced, which may be the result of current bugs in casperjs.

This pull request allows the xunit flag for casperjs to result in the creation of the xunit file, using `casper.test.renderResults`.