### PR TITLE
Enhancement/open report

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -237,6 +237,21 @@ function complete(){
   var compareConfigJSON = JSON.parse(compareConfigFile || '{}');
   compareConfigJSON.compareConfig = compareConfig;
   fs.write(compareConfigFileName, JSON.stringify(compareConfigJSON,null,2), 'w');
+
+  // Generate the xunit file if requested via a casper flag in the config.
+  var xunitFile;
+  if (config.casperFlags) {
+    config.casperFlags.forEach(function(casperFlag){
+      if (! xunitFile && casperFlag.match(/--xunit=(.*)$/)) {
+          xunitFile = casperFlag.match(/--xunit=(.*)$/)[1];
+      }
+    });
+  }
+
+  if (xunitFile) {
+    casper.test.renderResults(true, 0, xunitFile);
+  }
+
   console.log(
     'Comparison config file updated.'
     //,configData

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -80,6 +80,7 @@ gulp.task('test',['init'], function () {
     //exit if there was some kind of failure in the casperChild process
     if(code!=0){
       console.log('\nLooks like an error occured. You may want to try running `$ npm run echo`. This will echo the requested test URL output to the console. You can check this output to verify that the file requested is indeed being received in the expected format.');
+      var config = fs.readFileSync(paths.activeCaptureConfigPath, 'utf8');
       if (config.openReportIfCasperFailures) {
         return false;
       }

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -80,7 +80,9 @@ gulp.task('test',['init'], function () {
     //exit if there was some kind of failure in the casperChild process
     if(code!=0){
       console.log('\nLooks like an error occured. You may want to try running `$ npm run echo`. This will echo the requested test URL output to the console. You can check this output to verify that the file requested is indeed being received in the expected format.');
-      return false;
+      if (config.openReportIfCasperFailures) {
+        return false;
+      }
     }
 
     if(genReferenceMode){


### PR DESCRIPTION
We notice that, if casper tests are run and there are failures, then because `casperChild.on('close'` returns false and doesn't run `gulp.run('report')`.

We're proposing the addition of a new config flag, `openReportIfCasperFailures`, which will ensure that the backstop report is still shown in the browser, even if there are casper failures.

In our case, we're using the xunit file generated by casper to see the casper errors.