### PR TITLE
more detailed report why a comparison failed.

### DIFF
--- a/core/util/compare.js
+++ b/core/util/compare.js
@@ -64,7 +64,12 @@ module.exports = function (config) {
         }
 
         Test.status = 'fail';
-        logger.error('ERROR: ' + pair.label + ' ' + pair.fileName);
+
+        if (!data.isSameDimensions) {
+          logger.error('ERROR (dimensions mismatch): ' + pair.label + ' ' + pair.fileName);
+        } else {
+          logger.error('ERROR (' + data.misMatchPercentage + '% / ' + pair.misMatchThreshold + '%): ' + pair.label + ' ' + pair.fileName);
+        }
 
         return storeFailedDiffImage(testPath, data).then(function (compare) {
           pair.diffImage = compare;


### PR DESCRIPTION
Shows either `(dimensions mismatch)` or `(5% / 3%)` - reads as `five percent mismatch on a three percent threshold`.

Fix #306 , Helps #313 