### PR TITLE
Update node-resemble-js package to the latest version, this fixes #316

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "junitwriter": "~0.3.1",
     "lodash.map": "^4.6.0",
     "minimist": "^1.2.0",
-    "node-resemble-js": "0.0.4",
+    "node-resemble-js": "^0.1.1",
     "open": "0.0.5",
     "phantomjs-prebuilt": "^2.1.7",
     "temp": "^0.8.3"


### PR DESCRIPTION
I'm not quite sure if this works 100% because tests seem a little strange to say the least? In the freshly cloned repo, tests do not run because it tries to execute them in the directory of the user instead of the repo. I managed to run the tests after I commented out the "legacy mode" stuff, that prevents running tests in the repo (for whatever reason?). However after hacking the legacy mode stuff and updating the `node-resemble-js` package I was able to run `npm test` and it succeded (with mismatch errors).

I also tested the functionality in one of my projects (creating references and testing succeeded) - so I'm somewhat confident that this should work.