### PR TITLE
Pass isReference flag to onReadyScript and onBeforeScript

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -90,7 +90,7 @@ function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabe
 
     var onBeforeScript = scenario.onBeforeScript || config.onBeforeScript;
     if (onBeforeScript) {
-      require(getScriptPath(onBeforeScript))(casper, scenario, vp);
+      require(getScriptPath(onBeforeScript))(casper, scenario, vp, isReference);
     }
 
     this.thenOpen(url, function () {
@@ -136,7 +136,7 @@ function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabe
       //
       var onReadyScript = scenario.onReadyScript || config.onReadyScript;
       if (onReadyScript) {
-        require(getScriptPath(onReadyScript))(casper, scenario, vp);
+        require(getScriptPath(onReadyScript))(casper, scenario, vp, isReference);
       }
     });
 


### PR DESCRIPTION
I just upgraded to v2 and noticed that [my previous PR code](https://github.com/garris/BackstopJS/pull/246) to pass isReference to onReadyScript and onBeforeScript is gone.