### PR TITLE
fixes #323 compability for executable modules installed with yarn

### DIFF
--- a/core/util/findExecutable.js
+++ b/core/util/findExecutable.js
@@ -1,17 +1,18 @@
 var path = require('path');
 
-module.exports = function(module, bin) {
+module.exports = function (module, bin) {
 
-  if (module === 'phantomjs-prebuilt') {
-    return require('phantomjs-prebuilt').path;
+  try {
+    if (module === 'phantomjs-prebuilt') {
+      return require('phantomjs-prebuilt').path;
+    }
+
+    var pathToExecutableModulePackageJson = require.resolve(path.join(module, 'package.json'));
+    var executableModulePackageJson = require(pathToExecutableModulePackageJson);
+    var relativePathToExecutableBinary = executableModulePackageJson.bin[bin] || executableModulePackageJson.bin;
+    var pathToExecutableModule = pathToExecutableModulePackageJson.replace('package.json', '');
+    return path.join(pathToExecutableModule, relativePathToExecutableBinary);
+  } catch (e) {
+    throw new Error('Couldn\'t find executable for module "' + module + '" and bin "' + bin + '"\n' + e.message)
   }
-
-  // get the absolute path for package.json of a node_module
-  var packageJSON = require.resolve(path.join(module, 'package.json'));
-
-  // then get the executable name
-  var relativeBinary = require(packageJSON).bin[bin];
-
-  // return a path to the executable inside the execuatable's package
-  return path.join(packageJSON.replace('package.json', ''), relativeBinary);
 };

--- a/test/core/util/findExecutable_spec.js
+++ b/test/core/util/findExecutable_spec.js
@@ -1,0 +1,21 @@
+var mockery = require('mockery');
+var findExecutable = require('../../../core/util/findExecutable');
+var assert = require('assert');
+
+describe('findExecutable_spec.js', function () {
+  before(function () {
+    mockery.enable({useCleanCache:true});
+  });
+
+  it('should resolve the path to phantomjs-prebuilt correctly', function () {
+    mockery.registerMock('phantomjs-prebuilt', {path: 'path-to-phantomjs'});
+    var pathToPhantomjs = findExecutable('phantomjs-prebuilt');
+    assert.equal(pathToPhantomjs, 'path-to-phantomjs')
+  });
+
+  it('should print a meaningful error the executable cannot be found', function () {
+    assert.throws(function() {
+      findExecutable('no-installed-module', 'invalid-bin');
+    }, /Couldn't find executable for module "no-installed-module" and bin "invalid-bin"/);
+  });
+});


### PR DESCRIPTION
While npm uses the following structure for the bin section (which is the relevant part for this issue)
```json
{
  "bin": {
    "casperjs": "./bin/casperjs"
  },
}
```
Yarn uses the another structure
```json
{
  "bin": "./bin/casperjs"
}
```