### PR TITLE
--testReportFileName parameter is added for customized xunit filenames

### DIFF
--- a/core/command/report.js
+++ b/core/command/report.js
@@ -59,7 +59,8 @@ function writeBrowserReport (config, reporter) {
 
 function writeJunitReport (config, reporter) {
   logger.log('Writing jUnit Report');
-  var testReportFileName = config.ciReport.testReportFileName.replace(/\.xml$/, '') + '.xml';
+  var testReportFilename = config.testReportFileName || config.ciReport.testReportFileName;
+  testReportFileName = testReportFilename.replace(/\.xml$/, '') + '.xml';
 
   var testSuite = junitWriter.addTestsuite(reporter.testSuite);
 

--- a/core/util/makeConfig.js
+++ b/core/util/makeConfig.js
@@ -11,6 +11,12 @@ function projectPath(config) {
 }
 
 function loadProjectConfig(command, options, config) {
+  // TEST REPORT FILE NAME
+  var customTestReportFileName = options && (options.testReportFileName || null);
+  if(customTestReportFileName) {
+    config.testReportFileName = options.testReportFileName || null;
+  }
+
   var customConfigPath = options && (options.backstopConfigFilePath || options.configPath || options.config);
   if (customConfigPath) {
     if (path.isAbsolute(customConfigPath)) {


### PR DESCRIPTION
While using label filters existing xunit reports was being overwritten. This PR solves this issue by using custom report filenames via CLI parameter:

`backstop test --filter="label-1" --testReportFileName=label-1`

or

`backstop test --testReportFileName=custom`