### PR TITLE
Concurrency support with custom xunit filenames.

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -3,12 +3,29 @@ var DOCUMENT_SELECTOR = 'document';
 
 var fs = require('fs');
 var cwd = fs.workingDirectory;
+var system = require('system');
+var args = system.args;
+var val, index, captureConfigFileName;
+if (args.length !== 1) {
+  args.forEach(function (arg, i) {
+    arg = arg.split('--');
+    if (arg[1]) {
+      arg = arg[1].split('=');
+      val = arg[1];
+      index = arg[0];
+      if (index === 'captureConfigFileName') {
+        captureConfigFileName = val;
+      }
+    }
+  });
+}
+
 var scriptName = fs.absolute(require('system').args[3]);
 var __dirname = scriptName.substring(0, scriptName.lastIndexOf('/'));
 
 var selectorNotFoundPath = __dirname + '/resources/selectorNotFound_noun_164558_cc.png';
 var hiddenSelectorPath = __dirname + '/resources/hiddenSelector_noun_63405.png';
-var genConfigPath = __dirname + '/config.json'; // TODO :: find a way to use that directly from the main configuration
+var genConfigPath = captureConfigFileName; // TODO :: find a way to use that directly from the main configuration
 
 var config = require(genConfigPath);
 if (!config.paths) {

--- a/core/command/report.js
+++ b/core/command/report.js
@@ -59,7 +59,8 @@ function writeBrowserReport (config, reporter) {
 
 function writeJunitReport (config, reporter) {
   logger.log('Writing jUnit Report');
-  var testReportFileName = config.ciReport.testReportFileName.replace(/\.xml$/, '') + '.xml';
+  var testReportFilename = config.testReportFileName || config.ciReport.testReportFileName;
+  testReportFileName = testReportFilename.replace(/\.xml$/, '') + '.xml';
 
   var testSuite = junitWriter.addTestsuite(reporter.testSuite);
 

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -1,7 +1,10 @@
 var path = require('path');
 var temp = require('temp');
+var fs = require('fs');
+var hash = require('object-hash');
+const tmpdir = require('os').tmpdir();
 
-function extendConfig(config, userConfig) {
+function extendConfig (config, userConfig) {
   bitmapPaths(config, userConfig);
   ci(config, userConfig);
   htmlReport(config, userConfig);
@@ -18,7 +21,7 @@ function extendConfig(config, userConfig) {
   return config;
 }
 
-function bitmapPaths(config, userConfig) {
+function bitmapPaths (config, userConfig) {
   config.bitmaps_reference = path.join(config.projectPath, 'backstop_data', 'bitmaps_reference');
   config.bitmaps_test = path.join(config.projectPath, 'backstop_data', 'bitmaps_test');
   if (userConfig.paths) {
@@ -27,7 +30,7 @@ function bitmapPaths(config, userConfig) {
   }
 }
 
-function ci(config, userConfig) {
+function ci (config, userConfig) {
   config.ci_report = path.join(config.projectPath, 'backstop_data', 'ci_report');
   if (userConfig.paths) {
     config.ci_report = userConfig.paths.ci_report || config.ci_report;
@@ -47,7 +50,7 @@ function ci(config, userConfig) {
   }
 }
 
-function htmlReport(config, userConfig) {
+function htmlReport (config, userConfig) {
   config.html_report = path.join(config.projectPath, 'backstop_data', 'html_report');
   config.openReport = userConfig.openReport || true;
 
@@ -59,17 +62,22 @@ function htmlReport(config, userConfig) {
   config.compareReportURL = path.join(config.html_report, 'index.html');
 }
 
-function comparePaths(config) {
+function comparePaths (config) {
   config.comparePath = path.join(config.backstop, 'compare');
   config.tempCompareConfigFileName = temp.path({suffix: '.json'});
 }
 
-function captureConfigPaths(config) {
-  config.captureConfigFileName = path.join(config.backstop, 'capture', 'config.json');
+function captureConfigPaths (config) {
+  var captureDir = path.join(tmpdir, 'capture');
+  if (!fs.existsSync(captureDir)) {
+    fs.mkdirSync(captureDir);
+  }
+  var configHash = hash(config);
+  config.captureConfigFileName = path.join(tmpdir, 'capture', configHash + '.json');
   config.captureConfigFileNameDefault = path.join(config.backstop, 'capture', 'config.default.json');
 }
 
-function casper(config, userConfig) {
+function casper (config, userConfig) {
   config.casper_scripts = path.join(config.projectPath, 'backstop_data', 'casper_scripts');
   config.casper_scripts_default = path.join(config.backstop, 'capture', 'casper_scripts');
 

--- a/core/util/makeConfig.js
+++ b/core/util/makeConfig.js
@@ -11,6 +11,12 @@ function projectPath(config) {
 }
 
 function loadProjectConfig(command, options, config) {
+  // TEST REPORT FILE NAME
+  var customTestReportFileName = options && (options.testReportFileName || null);
+  if(customTestReportFileName) {
+    config.testReportFileName = options.testReportFileName || null;
+  }
+
   var customConfigPath = options && (options.backstopConfigFilePath || options.configPath || options.config);
   if (customConfigPath) {
     if (path.isAbsolute(customConfigPath)) {

--- a/core/util/runCasper.js
+++ b/core/util/runCasper.js
@@ -22,6 +22,9 @@ function getCasperArgs (config, tests) {
 
 module.exports = function (config, tests) {
   var casperArgs = getCasperArgs(config, tests);
+  if (config.captureConfigFileName) {
+    casperArgs[casperArgs.length] = '--captureConfigFileName=' + config.captureConfigFileName;
+  }
 
   console.log('\nRunning CasperJS with: ', casperArgs);
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "mockery": "^1.4.0"
   },
   "dependencies": {
+    "object-hash": "1.1.5",
+    "os": "^0.1.1",
     "bluebird": "^3.4.6",
     "casperjs": "^1.1.0-beta5",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Avoid writing to node_modules/backstopjs/

Issue described in here:

https://github.com/garris/BackstopJS/issues/363

few eslint warnings are fixed also.

--testReportFileName parameter is added for customized xunit filenames

While using label filters existing xunit reports was being overwritten. This PR solves this issue by using custom report filenames via CLI parameter:

backstop test --filter="label-1" --testReportFileName=label-1

or

backstop test --testReportFileName=custom