### PR TITLE
Various bugfixes

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -94,6 +94,25 @@ function capturePageSelectors (scenarios, viewports, bitmapsReferencePath, bitma
   });// end casper.each scenario
 }
 
+function getFilename(scenarioIndex, scenarioLabel, selectorIndex, selectorLabel, viewportIndex, viewportLabel) {
+  var fileName = fileNameTemplate
+    .replace(/\{configId\}/, configId)
+    .replace(/\{scenarioIndex\}/, scenarioIndex)
+    .replace(/\{scenarioLabel\}/, scenarioLabel)
+    .replace(/\{selectorIndex\}/, selectorIndex)
+    .replace(/\{selectorLabel\}/, selectorLabel)
+    .replace(/\{viewportIndex\}/, viewportIndex)
+    .replace(/\{viewportLabel\}/, makeSafe(viewportLabel))
+    .replace(/[^a-z0-9_\-]/gi, ''); // remove anything that's not a letter or a number or dash or underscore.
+
+  var extRegExp = new RegExp(outputFormat + '$', 'i');
+  if (!extRegExp.test(fileName)) {
+    fileName = fileName + outputFormat;
+  }
+
+  return fileName;
+}
+
 function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabel, viewports, bitmapsReferencePath, bitmapsTestPath, screenshotDateTime) {
   var scriptTimeout = 20000;
 
@@ -235,24 +254,10 @@ function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabe
 
       scenario.selectorsExpanded.forEach(function (o, i, a) {
         var cleanedSelectorName = o.replace(/[^a-z0-9_\-]/gi, ''); // remove anything that's not a letter or a number
-        var switchedScenarioOrVariantLabel = (isReference) ? scenarioLabel : scenarioOrVariantLabel;
 
-        var fileName = fileNameTemplate
-          .replace(/\{configId\}/, configId)
-          .replace(/\{scenarioIndex\}/, scenario.sIndex)
-          .replace(/\{scenarioLabel\}/, switchedScenarioOrVariantLabel) // derrived from scenario.label & variant.label
-          .replace(/\{selectorIndex\}/, i)
-          .replace(/\{selectorLabel\}/, cleanedSelectorName)
-          .replace(/\{viewportIndex\}/, viewportIndex)
-          .replace(/\{viewportLabel\}/, makeSafe(vp.name))
-          .replace(/[^a-z0-9_\-]/gi, ''); // remove anything that's not a letter or a number or dash or underscore.
+        var fileName = getFilename(scenario.sIndex, scenarioOrVariantLabel, i, cleanedSelectorName, viewportIndex, vp.name);
 
-        var extRegExp = new RegExp(outputFormat + '$', 'i');
-        if (!extRegExp.test(fileName)) {
-          fileName = fileName + outputFormat;
-        }
-
-        var referenceFilePath = bitmapsReferencePath + '/' + fileName;
+        var referenceFilePath = bitmapsReferencePath + '/' + getFilename(scenario.sIndex, scenarioLabel, i, cleanedSelectorName, viewportIndex, vp.name);
         var testFilePath = bitmapsTestPath + '/' + screenshotDateTime + '/' + fileName;
 
         var filePath = (isReference) ? referenceFilePath : testFilePath;

--- a/cli/index.js
+++ b/cli/index.js
@@ -45,4 +45,9 @@ if (!commandName) {
   process.on('exit', function () {
     process.exit(exitCode);
   });
+
+  process.on('uncaughtException', function(err) {
+    console.log("Uncaught exception:", err.message, err.stack);
+    throw err;
+  });
 }

--- a/core/command/report.js
+++ b/core/command/report.js
@@ -1,6 +1,8 @@
 var path = require('path');
+var chalk = require('chalk');
 var junitWriter = new (require('junitwriter'))();
 
+var allSettled = require('../util/allSettled');
 var fs = require('../util/fs');
 var logger = require('../util/logger')('report');
 var compare = require('../util/compare');
@@ -14,15 +16,12 @@ function writeReport (config, reporter) {
 
   promises.push(writeBrowserReport(config, reporter));
 
-  return Promise.all(promises);
+  return allSettled(promises);
 }
 
 function writeBrowserReport (config, reporter) {
   function toAbsolute (p) {
-    if (path.isAbsolute(p)) {
-      return p;
-    }
-    return path.join(config.projectPath, p);
+    return (path.isAbsolute(p))? p : path.join(config.projectPath, p);
   }
   logger.log('Writing browser report');
   return fs.copy(config.comparePath, toAbsolute(config.html_report)).then(function () {
@@ -59,8 +58,6 @@ function writeBrowserReport (config, reporter) {
 
 function writeJunitReport (config, reporter) {
   logger.log('Writing jUnit Report');
-  var testReportFilename = config.testReportFileName || config.ciReport.testReportFileName;
-  testReportFileName = testReportFilename.replace(/\.xml$/, '') + '.xml';
 
   var testSuite = junitWriter.addTestsuite(reporter.testSuite);
 
@@ -80,7 +77,9 @@ function writeJunitReport (config, reporter) {
   }
 
   return new Promise(function (resolve, reject) {
-    var destination = path.join(config.ci_report, testReportFileName);
+    var testReportFilename = config.testReportFileName || config.ciReport.testReportFileName;
+    testReportFilename = testReportFilename.replace(/\.xml$/, '') + '.xml';
+    var destination = path.join(config.ci_report, testReportFilename);
     junitWriter.save(destination, function (err) {
       if (err) {
         return reject(err);
@@ -97,18 +96,25 @@ module.exports = {
   execute: function (config) {
     return compare(config).then(function (report) {
       var failed = report.failed();
-      var passTag = '\x1b[32m', failTag = '\x1b[31m';
-      logger.log('\nTest completed...');
-      logger.log(passTag + report.passed() + ' Passed' + '\x1b[0m');
-      logger.log((failed ? failTag : passTag) + failed + ' Failed\n' + '\x1b[0m');
+      logger.log('Test completed...');
+      logger.log(chalk.green(report.passed() + ' Passed'));
+      logger.log(chalk[(failed ? 'red' : 'green')]( + failed + ' Failed'));
 
-      return writeReport(config, report).then(function () {
+      return writeReport(config, report).then(function (results) {
+        for (var i = 0; i < results.length; i++) {
+          if (results[i].state != 'fulfilled') {
+            logger.error("Failed writing report with error: " + results[i].value);
+          }
+        }
+
         if (failed) {
           logger.error('*** Mismatch errors found ***');
           logger.log('For a detailed report run `backstop openReport`\n');
           throw new Error('Mismatch errors found.');
         }
       });
+    }, function(e) {
+      logger.error("Comparison failed with error:" + e);
     });
   }
 };

--- a/core/util/allSettled.js
+++ b/core/util/allSettled.js
@@ -1,0 +1,9 @@
+module.exports = function (promises) {
+  return Promise.all(promises.map(function (promise) {
+    return promise.then(function (value) {
+      return { state: 'fulfilled', value: value };
+    }).catch(function (reason) {
+      return { state: 'rejected', reason: reason };
+    });
+  }));
+};

--- a/core/util/compare.js
+++ b/core/util/compare.js
@@ -1,6 +1,6 @@
 var resemble = require('node-resemble-js');
 var path = require('path');
-var map = require('bluebird').map;
+var map = require('p-map');
 
 var fs = require('fs');
 var streamToPromise = require('./streamToPromise');
@@ -37,18 +37,17 @@ function getFailedDiffFilename (testPath) {
 function compareImage (referencePath, testPath, resembleOutputSettings) {
   return new Promise(function (resolve, reject) {
     if (!fs.existsSync(referencePath)) {
-      reject('Reference image not found: ' + referencePath);
+      // Returning the error as a "resolve" so all errors can be caught instead of just the first one
+      return resolve(new Error('Reference image not found: ' + referencePath));
     }
 
     if (!fs.existsSync(testPath)) {
-      reject('Test image not found: ' + testPath);
+      // Returning the error as a "resolve" so all errors can be caught instead of just the first one
+      return resolve(new Error('Test image not found: ' + testPath));
     }
 
     resemble.outputSettings(resembleOutputSettings || {});
-    resemble(referencePath).compareTo(testPath)
-      .onComplete(function (data) {
-        resolve(data);
-      });
+    resemble(referencePath).compareTo(testPath).onComplete(resolve);
   });
 }
 
@@ -77,7 +76,13 @@ module.exports = function (config) {
         }
 
         Test.status = 'fail';
-        logger.error('ERROR { size: ' + (data.isSameDimensions ? 'ok' : 'isDifferent') + ', content: ' + data.misMatchPercentage + '%, threshold: ' + pair.misMatchThreshold + '% }: ' + pair.label + ' ' + pair.fileName);
+        if (data instanceof Error) {
+          logger.error('ERROR ' + data.message + ': ' + pair.label + ' ' + pair.fileName);
+          pair.error = data;
+          return pair;
+        } else {
+          logger.error('ERROR { size: ' + (data.isSameDimensions ? 'ok' : 'isDifferent') + ', content: ' + data.misMatchPercentage + '%, threshold: ' + pair.misMatchThreshold + '% }: ' + pair.label + ' ' + pair.fileName);
+        }
 
         return storeFailedDiffImage(testPath, data).then(function (compare) {
           pair.diffImage = compare;
@@ -89,5 +94,7 @@ module.exports = function (config) {
       });
   }, { concurrency: config.asyncCompareLimit || ASYNC_COMPARE_LIMIT }).then(function () {
     return report;
+  }, function(e) {
+    logger.error("The comparison failed with error: " + e);
   });
 };

--- a/package.json
+++ b/package.json
@@ -35,17 +35,16 @@
     "mockery": "^1.4.0"
   },
   "dependencies": {
-    "object-hash": "1.1.5",
-    "os": "^0.1.1",
-    "bluebird": "^3.4.6",
     "casperjs": "^1.1.0-beta5",
     "chalk": "^1.1.3",
     "fs-extra": "^0.30.0",
     "junitwriter": "~0.3.1",
-    "lodash.map": "^4.6.0",
     "minimist": "^1.2.0",
     "node-resemble-js": "^0.2.0",
+    "object-hash": "1.1.5",
     "open": "0.0.5",
+    "os": "^0.1.1",
+    "p-map": "^1.1.1",
     "phantomjs-prebuilt": "^2.1.7",
     "temp": "^0.8.3"
   }


### PR DESCRIPTION
Hi @garris,

I tried to update backstop and got a few surprises.

- When an error was thrown in `compareImage` not a single report was shown. (just stopped the process with an exit code of 0)
- Variants were not compared to the base reference image, but to a reference image that was never generated

So I made the following bugfixes for more robust error handling : 
- Centrally catch and log the unhandled errors
- use `allSettled` for report handling, that gives a change for a report to fail and give feedback on that error
- use `p-map` instead of `bluebird.map` because bluebird swallowed errors
- return errors in `compareImage` as `resolve(new Error(...)` so that we can accurately report all errors in image comparisons.

Other changes
- fix a typo in `core/command/report` for `testReportFileName`
- fix the way the filenames are generated when generating the bitmaps.