### PR TITLE
fixes config.openReport flag

### DIFF
--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -52,7 +52,7 @@ function ci (config, userConfig) {
 
 function htmlReport (config, userConfig) {
   config.html_report = path.join(config.projectPath, 'backstop_data', 'html_report');
-  config.openReport = userConfig.openReport == undefined ? true : userConfig.openReport;
+  config.openReport = userConfig.openReport === undefined ? true : userConfig.openReport;
 
   if (userConfig.paths) {
     config.html_report = userConfig.paths.html_report || config.html_report;

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -52,7 +52,7 @@ function ci (config, userConfig) {
 
 function htmlReport (config, userConfig) {
   config.html_report = path.join(config.projectPath, 'backstop_data', 'html_report');
-  config.openReport = userConfig.openReport || true;
+  config.openReport = userConfig.openReport == undefined ? true : userConfig.openReport;
 
   if (userConfig.paths) {
     config.html_report = userConfig.paths.html_report || config.html_report;


### PR DESCRIPTION
`config.openReport` flag was not working as extend config was always setting it to true.
It now uses the value provided in the config file.