### PR TITLE
New updated workflow feature: backstop approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ $ npm install -g backstopjs
 
   - **Configure:** Specify URLs, screen sizes, DOM selectors, ready events, interactions etc. (see examples directory)
 
-  - **Reference:** Create a set of *reference* screenshots. BackstopJS will consider this your *source of truth*. (Update this whenever you want).
+  - **Reference:** Create a set of *reference* screenshots. BackstopJS will consider this your *source of truth*.
 
-  - **Test:** BackstopJS creates a set of *test* screenshots and compares them with your *reference* screenshots. Any unwanted/unforeseen changes show up in a nice report.
+  - **Test:** BackstopJS creates a set of *test* screenshots and compares them with your *reference* screenshots. Any changes show up in a visual report. (Run this after making CSS changes as many times as needed.)
+
+  -  **Approve:** Often changes are exactly what you want. Approving changes will update your reference files with the results from your last test.
 
 
 ##Getting started
@@ -220,7 +222,21 @@ This will create a new set of bitmaps in `bitmaps_test/<timestamp>/`
 
 Once the test bitmaps are generated, a report comparing the most recent test bitmaps against the current reference bitmaps will run.
 
-Significant differences will be detected and displayed in the browser report.
+Changes will be detected and displayed in the browser report and a summary will show up in your terminal.
+
+
+
+
+###Approving changes
+
+```sh
+$ backstop approve
+```
+
+This will copy bitmaps from your latest test into your reference directory.  Subsequent tests will be compared against your updated reference files.
+
+SEE: [filtering tests and references by scenario](#Filtering-tests-and-references-by-scenario) for a note on approving changes after running `backstop test` using the `--filter` argument.
+
 
 ##Using BackstopJS
 
@@ -259,18 +275,23 @@ scenarios: [
 ```
 
 
-###Incremental scenario reference/testing (filtering)
+###Filtering tests and references by scenario
+
+If you only want to run a subset of your BackstopJS tests you can do so by invoking BackstopJS with the `--filter` argument. `--filter` takes a regEx string and compares it against your scenario labels. Non-matching scenarios are ignored.
+```
+$ backstop reference --filter=<scenario.label>
+```
+
+Note: If you run `backstop approve` after running a filtered test -- only matching test bitmaps will be promoted to your reference directory.
+
+
+###Incremental reference updates
 
 By default `backstop.reference` will first remove all files in your reference directory then generate screenshots of all selectors specified in your config file.
 
 If you don't want BackstopJS do first delete all files in your reference directory you can enable the `incremental` flag.
 ```
 $ backstop reference --i
-```
-
-If you need to run references or tests **only for _specific_ scenarios** you can do so by invoking BackstopJS with the `--filter` argument. (takes a regEx string)
-```
-$ backstop reference --i --filter=<scenario.label>
 ```
 
 

--- a/compare/css/styles.css
+++ b/compare/css/styles.css
@@ -17,11 +17,11 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
 .flex-container > div img {max-width: 100%;}
 
 .flex-container .selector,
-.flex-container .filename {background-color: #ddd;color:#444; padding: 5px 10px;}
-.flex-container .filename {text-align: right; color: #888; font-weight: 300;}
+.flex-container .filename {background-color: #ddd;color:#444; padding: 5px 5px; font-weight: 300;}
+.flex-container .filename {text-align: right;}
 
 .flex-container.small {font-size:0.85em;}
-.asset-heading {font-weight: 700;}
+.asset-heading {font-weight: 300;}
 
 .reportTxt{white-space: pre-wrap;font-family: monospace; font-size: 11px;}
 
@@ -38,7 +38,11 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
 .filterGroup {padding: 7px; background-color: #f0f0f0;}
 .filterGroup select {display: inline-block;width: auto;}
 
-.results {margin-bottom: 20px; break-inside: avoid;}
+.results {
+  margin-bottom: 90px;
+  break-inside: avoid;
+  border-top: #999 solid 1px;
+}
 
 .indicator{display: inline-block;font-style: italic;font-weight: 100;color: #999;}
 

--- a/compare/css/styles.css
+++ b/compare/css/styles.css
@@ -18,9 +18,10 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
 
 .flex-container .selector,
 .flex-container .filename {background-color: #ddd;color:#444; padding: 5px 10px;}
-.flex-container .filename {text-align: right; color: #888;}
+.flex-container .filename {text-align: right; color: #888; font-weight: 300;}
 
 .flex-container.small {font-size:0.85em;}
+.asset-heading {font-weight: 700;}
 
 .reportTxt{white-space: pre-wrap;font-family: monospace; font-size: 11px;}
 
@@ -37,7 +38,7 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
 .filterGroup {padding: 7px; background-color: #f0f0f0;}
 .filterGroup select {display: inline-block;width: auto;}
 
-.results {margin-bottom: 20px;}
+.results {margin-bottom: 20px; break-inside: avoid;}
 
 .indicator{display: inline-block;font-style: italic;font-weight: 100;color: #999;}
 
@@ -72,6 +73,10 @@ th{text-align: left;background: #ddd;padding: 10px;white-space: nowrap;}
 
 .control-label {
   margin-right: 3ex;
+}
+
+.show-diff {
+  display: none;
 }
 
 @media print {

--- a/compare/index.html
+++ b/compare/index.html
@@ -65,10 +65,10 @@
       <div class="filename">{{ thisTestPair.meta.pair.fileName }}</div>
     </div>
     <div class="flex-container small">
-      <div>Reference</div>
-      <div>Test</div>
-      <div ng-if="!thisTestPair.passed">Diff</div>
-      <div ng-if="showPairStats">Report</div>
+      <div class="asset-heading">REFERENCE</div>
+      <div class="asset-heading">TEST</div>
+      <div ng-if="!thisTestPair.passed" class="asset-heading">DIFF</div>
+      <div ng-if="showPairStats" class="asset-heading">REPORT</div>
     </div>
     <div class="flex-container">
       <div>

--- a/core/command/approve.js
+++ b/core/command/approve.js
@@ -1,0 +1,25 @@
+var fs = require('../util/fs');
+var path = require('path');
+var map = require('bluebird').map;
+
+var FAILED_DIFF_RE = /^failed_diff/
+
+// This task will copy ALL test bitmap files (from the most recent test directory) to the reference directory overwritting any exisiting files.
+module.exports = {
+  execute: function (config) {
+    // TODO:  IF Exists config.bitmaps_test  &&  list.length > 0n  (otherwise throw)
+    console.log('Copying bitmaps from ' + config.bitmaps_test + ' to ' + config.bitmaps_reference);
+    return fs.readdir(config.bitmaps_test,(err, list) => {
+      var src = path.join(config.bitmaps_test, list[list.length-1]);
+      return fs.readdir(src, (err, files) => {
+        return map(files, (file) => {
+          if (FAILED_DIFF_RE.test(file)) {
+            return true;
+          }
+          console.log("Copy > ", file));
+          return fs.copy(path.join(src, file), path.join(config.bitmaps_reference, file))
+        })
+      });
+    });
+  }
+};

--- a/core/command/approve.js
+++ b/core/command/approve.js
@@ -16,7 +16,7 @@ module.exports = {
           if (FAILED_DIFF_RE.test(file)) {
             return true;
           }
-          console.log("Copy > ", file));
+          console.log("Approved > " + file);
           return fs.copy(path.join(src, file), path.join(config.bitmaps_reference, file))
         })
       });

--- a/core/command/approve.js
+++ b/core/command/approve.js
@@ -1,6 +1,6 @@
 var fs = require('../util/fs');
 var path = require('path');
-var map = require('bluebird').map;
+var map = require('p-map');
 
 var FAILED_DIFF_RE = /^failed_diff/
 
@@ -8,16 +8,17 @@ var FAILED_DIFF_RE = /^failed_diff/
 module.exports = {
   execute: function (config) {
     // TODO:  IF Exists config.bitmaps_test  &&  list.length > 0n  (otherwise throw)
-    console.log('Copying bitmaps from ' + config.bitmaps_test + ' to ' + config.bitmaps_reference);
+    console.log('Copying from ' + config.bitmaps_test + ' to ' + config.bitmaps_reference + '.');
     return fs.readdir(config.bitmaps_test,(err, list) => {
       var src = path.join(config.bitmaps_test, list[list.length-1]);
       return fs.readdir(src, (err, files) => {
+        console.log('The following files will be promoted to reference...');
         return map(files, (file) => {
           if (FAILED_DIFF_RE.test(file)) {
             return true;
           }
-          console.log("Approved > " + file);
-          return fs.copy(path.join(src, file), path.join(config.bitmaps_reference, file))
+          console.log('> ', file);
+          return fs.copy(path.join(src, file), path.join(config.bitmaps_reference, file));
         })
       });
     });

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -16,7 +16,8 @@ var commandNames = [
   'openReport',
   'reference',
   'report',
-  'test'
+  'test',
+  'approve'
 ];
 
 /* Commands that are only exposed to higher levels */
@@ -24,7 +25,8 @@ var exposedCommandNames = [
   'genConfig',
   'reference',
   'test',
-  'openReport'
+  'openReport',
+  'approve'
 ];
 
 /* Used to convert an array of objects {name, execute} to a unique object {[name]: execute} */

--- a/core/util/fs.js
+++ b/core/util/fs.js
@@ -3,6 +3,7 @@ var fsExtra = require('fs-extra');
 var promisify = require('./promisify');
 
 var fsPromisified = {
+  readdir: promisify(fs.readdir),
   createWriteStream: fs.createWriteStream,
   existsSync: fs.existsSync,
   readFile: promisify(fs.readFile),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"


### PR DESCRIPTION
`backstop approve` will copy bitmaps from your latest test into your reference directory.  Subsequent tests will be compared against your updated reference files.

Provides a straightforward way to approve changes.

I could also see adding `--filter=<scenario.label || selector>` and `-d` (dry run) arguments to enable approving a more narrow selection.