### PR TITLE
fixes 0 not being recognized as misMatchThreshold value

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -266,13 +266,23 @@ function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabe
             selector: o,
             fileName: fileName,
             label: scenario.label,
-            misMatchThreshold: scenario.misMatchThreshold || config.misMatchThreshold || config.defaultMisMatchThreshold
+            misMatchThreshold: getMisMatchThreshHold(scenario)
           });
         }
         // casper.echo('remote capture to > '+filePath,'info');
       });// end topLevelModules.forEach
     });
   });// end casper.each viewports
+}
+
+function getMisMatchThreshHold(scenario) {
+  if (typeof scenario.misMatchThreshold != 'undefined')
+    return scenario.misMatchThreshold;
+
+  if (typeof config.misMatchThreshold != 'undefined')
+    return config.misMatchThreshold;
+
+  return config.defaultMisMatchThreshold
 }
 
 function captureScreenshot (casper, filePath, selector) {


### PR DESCRIPTION
Based on https://github.com/garris/BackstopJS/issues/127 this commit adds the possibility to set the threshold to exactly 0.

At the moment this is impossible because of the way the parameter is read from the scenario or config.