### PR TITLE
Set compare html charset to UTF-8

### DIFF
--- a/compare/index.html
+++ b/compare/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
+
   <title>BackstopJS Report</title>
 
   <link rel="stylesheet" type="text/css" href="bower_components/bootstrap-css-only/css/bootstrap.min.css">


### PR DESCRIPTION
I was trying to use symbols in my scenario labels, but they were coming out garbled because the browser wasn't interpreting it as UTF-8.  This adds a meta tag to make the compare report UTF-8 so they render correctly.