### PR TITLE
+ Added property readyEventTimeout to backstop.json file, to support …

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -34,6 +34,7 @@
         "footer"
       ],
       "readyEvent": null,
+      "readyEventTimeout": 20000,
       "delay": 500,
       "misMatchThreshold" : 0.1,
       "onBeforeScript": "onBefore.js",

--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -114,7 +114,7 @@ function getFilename (scenarioIndex, scenarioLabel, selectorIndex, selectorLabel
 }
 
 function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabel, viewports, bitmapsReferencePath, bitmapsTestPath, screenshotDateTime) {
-  var scriptTimeout = 20000;
+  var scriptTimeout = scenario.readyEventTimeout || 20000;
 
   if (casper.cli.options.user && casper.cli.options.password) {
     console.log('Auth User via CLI: ' + casper.cli.options.user);


### PR DESCRIPTION
…scenario based timeouts for readyEvent property

Different scenarios could have different timeouts for page loading. At lease, it should be even possible to handle timeout configuration in backstop.json, and not have 20000 integer to be hardcoded in capture/genBitmaps.js