### PR TITLE
Add cookies to bitmaps right before each scenario has run

### DIFF
--- a/capture/genBitmaps.js
+++ b/capture/genBitmaps.js
@@ -123,17 +123,16 @@ function processScenario (casper, scenario, scenarioOrVariantLabel, scenarioLabe
 
   casper.each(viewports, function (casper, vp, viewportIndex) {
     this.then(function () {
+      var onBeforeScript = scenario.onBeforeScript || config.onBeforeScript;
+      if (onBeforeScript) {
+        require(getScriptPath(onBeforeScript))(casper, scenario, vp, isReference);
+      }
       this.viewport(vp.width || vp.viewport.width, vp.height || vp.viewport.height);
     });
 
     var url = scenario.url;
     if (isReference && scenario.referenceUrl) {
       url = scenario.referenceUrl;
-    }
-
-    var onBeforeScript = scenario.onBeforeScript || config.onBeforeScript;
-    if (onBeforeScript) {
-      require(getScriptPath(onBeforeScript))(casper, scenario, vp, isReference);
     }
 
     this.thenOpen(url, function () {


### PR DESCRIPTION
This will set each cookie to its relevant scenario right before its run, rather than setting all of the cookies at the start of the casper instance. The upshot to this is that we'll be able to set custom cookies for any specific scenario!