### PR TITLE
Allow absolute paths for snapshot directories

### DIFF
--- a/core/util/compare.js
+++ b/core/util/compare.js
@@ -69,8 +69,8 @@ module.exports = function (config) {
   return map(compareConfig.testPairs, function (pair) {
     var Test = report.addTest(pair);
 
-    var referencePath = path.join(config.projectPath, pair.reference);
-    var testPath = path.join(config.projectPath, pair.test);
+    var referencePath = path.resolve(config.projectPath, pair.reference);
+    var testPath = path.resolve(config.projectPath, pair.test);
 
     return compareImage(referencePath, testPath, config.resembleOutputOptions)
       .then(function logCompareResult (data) {


### PR DESCRIPTION
Hi, thank you for the great tool! I'm using it in some projects and it is really helpful!

I'm making this PR because I realized BackstopJS does not handle absolute paths in `paths.bitmaps_reference` and `paths.bitmaps_text`. This is not a problem in ordinary projects but I'm facing the case that needs to use absolute paths in it. This PR allows us to set absolute paths in the config.

You can confirm the current behavior by the following reproduction.
https://github.com/ktsn/backstop-compare-test

By the way, I'm not sure how we should write test code for such the fix. If it is needed, please let me know.

Thanks!