### PR TITLE
Do not set PHANTOMJS_EXECUTABLE under all circumstances

### DIFF
--- a/core/util/runCasper.js
+++ b/core/util/runCasper.js
@@ -30,7 +30,10 @@ module.exports = function (config, tests) {
 
   console.log('\nRunning CasperJS with: ', casperArgs);
 
-  process.env.PHANTOMJS_EXECUTABLE = findExecutable('phantomjs-prebuilt', 'phantomjs');
+  var phantomjsExecutable = findExecutable('phantomjs-prebuilt', 'phantomjs');
+  if (phantomjsExecutable && typeof process.env.PHANTOMJS_EXECUTABLE === "undefined") {
+    process.env.PHANTOMJS_EXECUTABLE = phantomjsExecutable;
+  }
 
   var casperProcess = findExecutable('casperjs', 'casperjs');
   var casperChild = spawn(casperProcess, casperArgs, {cwd: config.projectPath});


### PR DESCRIPTION
There are two cases in which `PHANTOMJS_EXECUTABLE` should not be set, I
think:

1. If the return value of `findExecutable('phantomjs-prebuilt', 'phantomjs')`
   is null. This might be the case [because the path export of the phantomjs module
   can be null](https://github.com/Medium/phantomjs/blob/master/lib/phantomjs.js#L25).
2. If `PHANTOMJS_EXECUTABLE` is already set from outside.

Should solve most of #346.