### PR TITLE
Chromy: Prevent uncaught errors and make them available for the parent application

### DIFF
--- a/core/util/BackstopException.js
+++ b/core/util/BackstopException.js
@@ -1,0 +1,15 @@
+module.exports = class BackstopException {
+  constructor(msg, scenario, viewport, originalError) {
+    this.msg = msg;
+    this.scenario = scenario;
+    this.viewport = viewport;
+    this.originalError = originalError;
+  }
+
+  toString() {
+    return 'BackstopExcpetion: '
+      + this.scenario.label + ' on '
+      + this.viewport.name + ': '
+      + this.originalError.toString();
+  }
+}

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -17,6 +17,8 @@ const DOCUMENT_SELECTOR = 'document';
 const NOCLIP_SELECTOR = 'body:noclip';
 const VIEWPORT_SELECTOR = 'viewport';
 
+const BackstopException = require('../util/BackstopException.js');
+
 // ============================== TEST VVVVV ===========================
 
 function hasLogged (str) {
@@ -383,7 +385,8 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
           _result.backstopSelectorsExpMap
         ));
       })
-      .end();
+      .end()
+      .catch(e => reject(new BackstopException('Chromy error', scenario, viewport, e)))
   });
 }
 


### PR DESCRIPTION
Hi!

Chromy errors are not rethrown correctly. i.E. if I call chromy.wait with an invalid selector in a scenario, my console only prints "(node:86933) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TimeoutError: timeout", but I can neither catch the error (because it is not rethrown properly) nor find additional information (like scenario or label). Since a timeout occures > 30 seconds asynchronously and I have hundreds of tests running at once, I have no idea what went wrong and am pretty much lost.

This commit adds a nice error that bubbles up so that an outer application may react. If no outer catch exists scenario and viewport details are shown in the console so the user knows where to look for the mistake.