### PR TITLE
Inject backstopTools

### DIFF
--- a/backstop_data/engine_scripts/goToNextPage.js
+++ b/backstop_data/engine_scripts/goToNextPage.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = (chromy, scenario, vp) => {
-    chromy.goto('https://github.com/garris/BackstopJS/issues');
-};

--- a/backstop_data/engine_scripts/goToNextPage.js
+++ b/backstop_data/engine_scripts/goToNextPage.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = (chromy, scenario, vp) => {
+    chromy.goto('https://github.com/garris/BackstopJS/issues');
+};

--- a/capture/backstopTools.js
+++ b/capture/backstopTools.js
@@ -1,94 +1,102 @@
-var BODY_SELECTOR = 'body';
-var DOCUMENT_SELECTOR = 'document';
-var VIEWPORT_SELECTOR = 'viewport';
-var INJECT_CSS = 'html {-webkit-font-smoothing: antialiased;}';
+'use strict';
+module.exports = (chromy) => {
+    return chromy.evaluate(() => {
+        var BODY_SELECTOR = 'body';
+        var DOCUMENT_SELECTOR = 'document';
+        var VIEWPORT_SELECTOR = 'viewport';
+        var INJECT_CSS = 'html {-webkit-font-smoothing: antialiased;}';
 
-function injectStyle (cssSting) {
-  var styleTag = document.createElement('style');
-  styleTag.innerHTML = cssSting;
-  document.body.appendChild(styleTag);
-}
-injectStyle(INJECT_CSS);
-
-/**
- * Take an array of selector names and return and array of *all* matching selectors.
- * For each selector name, If more than 1 selector is matched, proceeding matches are
- * tagged with an additional `__n` class.
- *
- * @param  {[string]} collapsed list of selectors
- * @return {[string]} [array of expanded selectors]
- */
-window.expandSelectors = function (selectors) {
-  if (!Array.isArray(selectors)) {
-    selectors = selectors.split(',');
-  }
-  return selectors.reduce(function (acc, selector) {
-    if (selector === BODY_SELECTOR || selector === VIEWPORT_SELECTOR) {
-      return acc.concat([selector]);
-    }
-    if (selector === DOCUMENT_SELECTOR) {
-      return acc.concat([DOCUMENT_SELECTOR]);
-    }
-    var qResult = document.querySelectorAll(selector);
-
-    // pass-through any selectors that don't match any DOM elements
-    if (!qResult.length) {
-      return acc.concat(selector);
-    }
-
-    var expandedSelector = [].slice.call(qResult)
-      .map(function (element, expandedIndex) {
-        if (element.classList.contains('__86d')) {
-          return '';
+        function injectStyle (cssString) {
+            var styleTag = document.createElement('style');
+            styleTag.innerHTML = cssString;
+            document.body.appendChild(styleTag);
         }
-        if (!expandedIndex) {
-          // only first element is used for screenshots -- even if multiple instances exist.
-          // therefore index 0 does not need extended qualification.
-          return selector;
-        }
-        // create index partial
-        var indexPartial = '__n' + expandedIndex;
-        // update all matching selectors with additional indexPartial class
-        element.classList.add(indexPartial);
-        // return array of fully-qualified classnames
-        return selector + '.' + indexPartial;
-      });
-    // concat arrays of fully-qualified classnames
-    return acc.concat(expandedSelector);
-  }, []).filter(function (selector) {
-    return selector !== '';
-  });
-};
 
-window.isVisible = function (selector) {
-  if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-    return true;
-  } else if (window.exists(selector)) {
-    const element = document.querySelector(selector);
-    const style = window.getComputedStyle(element);
-    return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
-  }
-  return false;
-};
+        injectStyle(INJECT_CSS);
 
-window.exists = function (selector) {
-  if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-    return 1;
-  }
-  return document.querySelectorAll(selector).length;
-};
+        /**
+         * Take an array of selector names and return and array of *all* matching selectors.
+         * For each selector name, If more than 1 selector is matched, proceeding matches are
+         * tagged with an additional `__n` class.
+         *
+         * @param  {[string]} collapsed list of selectors
+         * @return {[string]} [array of expanded selectors]
+         */
+        window.expandSelectors = function (selectors) {
+            if (!Array.isArray(selectors)) {
+                selectors = selectors.split(',');
+            }
+            return selectors.reduce(function (acc, selector) {
+                if (selector === BODY_SELECTOR || selector === VIEWPORT_SELECTOR) {
+                    return acc.concat([selector]);
+                }
+                if (selector === DOCUMENT_SELECTOR) {
+                    return acc.concat([DOCUMENT_SELECTOR]);
+                }
+                var qResult = document.querySelectorAll(selector);
 
-var _consoleLogger = '';
-window._hasLogged = function (str) {
-  return new RegExp(str).test(_consoleLogger);
-};
-function startConsoleLogger () {
-  var log = console.log.bind(console);
-  console.log = function () {
-    _consoleLogger += Array.from(arguments).join('\n');
-    log.apply(this, arguments);
-  };
-}
-startConsoleLogger();
+                // pass-through any selectors that don't match any DOM elements
+                if (!qResult.length) {
+                    return acc.concat(selector);
+                }
 
-console.info('backstopTools are running');
+                var expandedSelector = [].slice.call(qResult)
+                    .map(function (element, expandedIndex) {
+                        if (element.classList.contains('__86d')) {
+                            return '';
+                        }
+                        if (!expandedIndex) {
+                            // only first element is used for screenshots -- even if multiple instances exist.
+                            // therefore index 0 does not need extended qualification.
+                            return selector;
+                        }
+                        // create index partial
+                        var indexPartial = '__n' + expandedIndex;
+                        // update all matching selectors with additional indexPartial class
+                        element.classList.add(indexPartial);
+                        // return array of fully-qualified classnames
+                        return selector + '.' + indexPartial;
+                    });
+                // concat arrays of fully-qualified classnames
+                return acc.concat(expandedSelector);
+            }, []).filter(function (selector) {
+                return selector !== '';
+            });
+        };
+
+        window.isVisible = function (selector) {
+            if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
+                return true;
+            } else if (window.exists(selector)) {
+                const element = document.querySelector(selector);
+                const style = window.getComputedStyle(element);
+                return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
+            }
+            return false;
+        };
+
+        window.exists = function (selector) {
+            if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
+                return 1;
+            }
+            return document.querySelectorAll(selector).length;
+        };
+
+        window.hasLogged = function(str) {
+            return new RegExp(str).test(window._consoleLogger);
+        };
+
+        window.startConsoleLogger = function() {
+            if (typeof window._consoleLogger !== 'string') {
+                window._consoleLogger = '';
+            }
+            var log = window.console.log.bind(console);
+            window.console.log = function () {
+                window._consoleLogger += Array.from(arguments).join('\n');
+                log.apply(this, arguments);
+            };
+        };
+
+        console.info('backstopTools are running');
+    });
+};

--- a/capture/backstopTools.js
+++ b/capture/backstopTools.js
@@ -1,103 +1,99 @@
 'use strict';
 module.exports = (chromy) => {
   return chromy.evaluate(() => {
-    var BODY_SELECTOR = 'body';
-    var DOCUMENT_SELECTOR = 'document';
-    var VIEWPORT_SELECTOR = 'viewport';
-    var INJECT_CSS = 'html {-webkit-font-smoothing: antialiased;}';
 
-    function injectStyle(cssString) {
-      var styleTag = document.createElement('style');
-      styleTag.innerHTML = cssString;
-      document.body.appendChild(styleTag);
-    }
-
-    injectStyle(INJECT_CSS);
-
-    /**
-     * Take an array of selector names and return and array of *all* matching selectors.
-     * For each selector name, If more than 1 selector is matched, proceeding matches are
-     * tagged with an additional `__n` class.
-     *
-     * @param  {[string]} collapsed list of selectors
-     * @return {[string]} [array of expanded selectors]
-     */
-    window.expandSelectors = function (selectors) {
-      if (!Array.isArray(selectors)) {
-        selectors = selectors.split(',');
-      }
-      return selectors.reduce(function (acc, selector) {
-        if (selector === BODY_SELECTOR || selector === VIEWPORT_SELECTOR) {
-          return acc.concat([selector]);
+    window._backstopTools = {
+      hasLogged: function (str) {
+        return new RegExp(str).test(window._backstopTools._consoleLogger);
+      },
+      startConsoleLogger: function () {
+        if (typeof window._backstopTools._consoleLogger !== 'string') {
+          window._backstopTools._consoleLogger = '';
         }
-        if (selector === DOCUMENT_SELECTOR) {
-          return acc.concat([DOCUMENT_SELECTOR]);
+        var log = window.console.log.bind(console);
+        window.console.log = function () {
+          window._backstopTools._consoleLogger += Array.from(arguments).join('\n');
+          log.apply(this, arguments);
+        };
+      },
+      /**
+       * Take an array of selector names and return and array of *all* matching selectors.
+       * For each selector name, If more than 1 selector is matched, proceeding matches are
+       * tagged with an additional `__n` class.
+       *
+       * @return {[string]} [array of expanded selectors]
+       * @param selectors
+       */
+      expandSelectors: function (selectors) {
+        if (!Array.isArray(selectors)) {
+          selectors = selectors.split(',');
         }
-        var qResult = document.querySelectorAll(selector);
+        return selectors.reduce(function (acc, selector) {
+          if (selector === 'body' || selector === 'viewport') {
+            return acc.concat([selector]);
+          }
+          if (selector === 'document') {
+            return acc.concat(['document']);
+          }
+          var qResult = document.querySelectorAll(selector);
 
-        // pass-through any selectors that don't match any DOM elements
-        if (!qResult.length) {
-          return acc.concat(selector);
+          // pass-through any selectors that don't match any DOM elements
+          if (!qResult.length) {
+            return acc.concat(selector);
+          }
+
+          var expandedSelector = [].slice.call(qResult)
+            .map(function (element, expandedIndex) {
+              if (element.classList.contains('__86d')) {
+                return '';
+              }
+              if (!expandedIndex) {
+                // only first element is used for screenshots -- even if multiple instances exist.
+                // therefore index 0 does not need extended qualification.
+                return selector;
+              }
+              // create index partial
+              var indexPartial = '__n' + expandedIndex;
+              // update all matching selectors with additional indexPartial class
+              element.classList.add(indexPartial);
+              // return array of fully-qualified classnames
+              return selector + '.' + indexPartial;
+            });
+          // concat arrays of fully-qualified classnames
+          return acc.concat(expandedSelector);
+        }, []).filter(function (selector) {
+          return selector !== '';
+        });
+      },
+      /**
+       * is the selector element visible?
+       * @param  {[type]}  selector [a css selector str]
+       * @return {Boolean}          [is it visible? true or false]
+       */
+      isVisible: function (selector) {
+        if (selector === 'body' || selector === 'document' || selector === 'viewport') {
+          return true;
+        } else if (window._backstopTools.exists(selector)) {
+          const element = document.querySelector(selector);
+          const style = window.getComputedStyle(element);
+          return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
         }
-
-        var expandedSelector = [].slice.call(qResult)
-          .map(function (element, expandedIndex) {
-            if (element.classList.contains('__86d')) {
-              return '';
-            }
-            if (!expandedIndex) {
-              // only first element is used for screenshots -- even if multiple instances exist.
-              // therefore index 0 does not need extended qualification.
-              return selector;
-            }
-            // create index partial
-            var indexPartial = '__n' + expandedIndex;
-            // update all matching selectors with additional indexPartial class
-            element.classList.add(indexPartial);
-            // return array of fully-qualified classnames
-            return selector + '.' + indexPartial;
-          });
-        // concat arrays of fully-qualified classnames
-        return acc.concat(expandedSelector);
-      }, []).filter(function (selector) {
-        return selector !== '';
-      });
-    };
-
-    window.isVisible = function (selector) {
-      if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-        return true;
-      } else if (window.exists(selector)) {
-        const element = document.querySelector(selector);
-        const style = window.getComputedStyle(element);
-        return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
+        return false;
+      },
+      /**
+       * does the selector element exist?
+       * @param  {[type]} selector [a css selector str]
+       * @return {[type]}          [returns count of found matches -- 0 for no matches]
+       */
+      exists: function (selector) {
+        if (selector === 'body' || selector === 'document' || selector === 'viewport') {
+          return 1;
+        }
+        return document.querySelectorAll(selector).length;
       }
-      return false;
     };
 
-    window.exists = function (selector) {
-      if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-        return 1;
-      }
-      return document.querySelectorAll(selector).length;
-    };
-
-    window.hasLogged = function (str) {
-      return new RegExp(str).test(window._consoleLogger);
-    };
-
-    window.startConsoleLogger = function () {
-      if (typeof window._consoleLogger !== 'string') {
-        window._consoleLogger = '';
-      }
-      var log = window.console.log.bind(console);
-      window.console.log = function () {
-        window._consoleLogger += Array.from(arguments).join('\n');
-        log.apply(this, arguments);
-      };
-    };
-
-    startConsoleLogger();
+    window._backstopTools.startConsoleLogger();
     console.info('backstopTools are running');
   });
 };

--- a/capture/backstopTools.js
+++ b/capture/backstopTools.js
@@ -1,103 +1,103 @@
 'use strict';
 module.exports = (chromy) => {
-    return chromy.evaluate(() => {
-        var BODY_SELECTOR = 'body';
-        var DOCUMENT_SELECTOR = 'document';
-        var VIEWPORT_SELECTOR = 'viewport';
-        var INJECT_CSS = 'html {-webkit-font-smoothing: antialiased;}';
+  return chromy.evaluate(() => {
+    var BODY_SELECTOR = 'body';
+    var DOCUMENT_SELECTOR = 'document';
+    var VIEWPORT_SELECTOR = 'viewport';
+    var INJECT_CSS = 'html {-webkit-font-smoothing: antialiased;}';
 
-        function injectStyle (cssString) {
-            var styleTag = document.createElement('style');
-            styleTag.innerHTML = cssString;
-            document.body.appendChild(styleTag);
+    function injectStyle(cssString) {
+      var styleTag = document.createElement('style');
+      styleTag.innerHTML = cssString;
+      document.body.appendChild(styleTag);
+    }
+
+    injectStyle(INJECT_CSS);
+
+    /**
+     * Take an array of selector names and return and array of *all* matching selectors.
+     * For each selector name, If more than 1 selector is matched, proceeding matches are
+     * tagged with an additional `__n` class.
+     *
+     * @param  {[string]} collapsed list of selectors
+     * @return {[string]} [array of expanded selectors]
+     */
+    window.expandSelectors = function (selectors) {
+      if (!Array.isArray(selectors)) {
+        selectors = selectors.split(',');
+      }
+      return selectors.reduce(function (acc, selector) {
+        if (selector === BODY_SELECTOR || selector === VIEWPORT_SELECTOR) {
+          return acc.concat([selector]);
+        }
+        if (selector === DOCUMENT_SELECTOR) {
+          return acc.concat([DOCUMENT_SELECTOR]);
+        }
+        var qResult = document.querySelectorAll(selector);
+
+        // pass-through any selectors that don't match any DOM elements
+        if (!qResult.length) {
+          return acc.concat(selector);
         }
 
-        injectStyle(INJECT_CSS);
-
-        /**
-         * Take an array of selector names and return and array of *all* matching selectors.
-         * For each selector name, If more than 1 selector is matched, proceeding matches are
-         * tagged with an additional `__n` class.
-         *
-         * @param  {[string]} collapsed list of selectors
-         * @return {[string]} [array of expanded selectors]
-         */
-        window.expandSelectors = function (selectors) {
-            if (!Array.isArray(selectors)) {
-                selectors = selectors.split(',');
+        var expandedSelector = [].slice.call(qResult)
+          .map(function (element, expandedIndex) {
+            if (element.classList.contains('__86d')) {
+              return '';
             }
-            return selectors.reduce(function (acc, selector) {
-                if (selector === BODY_SELECTOR || selector === VIEWPORT_SELECTOR) {
-                    return acc.concat([selector]);
-                }
-                if (selector === DOCUMENT_SELECTOR) {
-                    return acc.concat([DOCUMENT_SELECTOR]);
-                }
-                var qResult = document.querySelectorAll(selector);
-
-                // pass-through any selectors that don't match any DOM elements
-                if (!qResult.length) {
-                    return acc.concat(selector);
-                }
-
-                var expandedSelector = [].slice.call(qResult)
-                    .map(function (element, expandedIndex) {
-                        if (element.classList.contains('__86d')) {
-                            return '';
-                        }
-                        if (!expandedIndex) {
-                            // only first element is used for screenshots -- even if multiple instances exist.
-                            // therefore index 0 does not need extended qualification.
-                            return selector;
-                        }
-                        // create index partial
-                        var indexPartial = '__n' + expandedIndex;
-                        // update all matching selectors with additional indexPartial class
-                        element.classList.add(indexPartial);
-                        // return array of fully-qualified classnames
-                        return selector + '.' + indexPartial;
-                    });
-                // concat arrays of fully-qualified classnames
-                return acc.concat(expandedSelector);
-            }, []).filter(function (selector) {
-                return selector !== '';
-            });
-        };
-
-        window.isVisible = function (selector) {
-            if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-                return true;
-            } else if (window.exists(selector)) {
-                const element = document.querySelector(selector);
-                const style = window.getComputedStyle(element);
-                return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
+            if (!expandedIndex) {
+              // only first element is used for screenshots -- even if multiple instances exist.
+              // therefore index 0 does not need extended qualification.
+              return selector;
             }
-            return false;
-        };
+            // create index partial
+            var indexPartial = '__n' + expandedIndex;
+            // update all matching selectors with additional indexPartial class
+            element.classList.add(indexPartial);
+            // return array of fully-qualified classnames
+            return selector + '.' + indexPartial;
+          });
+        // concat arrays of fully-qualified classnames
+        return acc.concat(expandedSelector);
+      }, []).filter(function (selector) {
+        return selector !== '';
+      });
+    };
 
-        window.exists = function (selector) {
-            if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
-                return 1;
-            }
-            return document.querySelectorAll(selector).length;
-        };
+    window.isVisible = function (selector) {
+      if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
+        return true;
+      } else if (window.exists(selector)) {
+        const element = document.querySelector(selector);
+        const style = window.getComputedStyle(element);
+        return (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
+      }
+      return false;
+    };
 
-        window.hasLogged = function(str) {
-            return new RegExp(str).test(window._consoleLogger);
-        };
+    window.exists = function (selector) {
+      if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR || selector === VIEWPORT_SELECTOR) {
+        return 1;
+      }
+      return document.querySelectorAll(selector).length;
+    };
 
-        window.startConsoleLogger = function() {
-            if (typeof window._consoleLogger !== 'string') {
-                window._consoleLogger = '';
-            }
-            var log = window.console.log.bind(console);
-            window.console.log = function () {
-                window._consoleLogger += Array.from(arguments).join('\n');
-                log.apply(this, arguments);
-            };
-        };
+    window.hasLogged = function (str) {
+      return new RegExp(str).test(window._consoleLogger);
+    };
 
-        startConsoleLogger();
-        console.info('backstopTools are running');
-    });
+    window.startConsoleLogger = function () {
+      if (typeof window._consoleLogger !== 'string') {
+        window._consoleLogger = '';
+      }
+      var log = window.console.log.bind(console);
+      window.console.log = function () {
+        window._consoleLogger += Array.from(arguments).join('\n');
+        log.apply(this, arguments);
+      };
+    };
+
+    startConsoleLogger();
+    console.info('backstopTools are running');
+  });
 };

--- a/capture/backstopTools.js
+++ b/capture/backstopTools.js
@@ -97,6 +97,7 @@ module.exports = (chromy) => {
             };
         };
 
+        startConsoleLogger();
         console.info('backstopTools are running');
     });
 };

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -235,12 +235,9 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     injectBackstopTools(chromy);
 
     chromy
-      // .inject('js', config.env.backstop + BACKSTOP_TOOLS_PATH)
       .evaluate(`window._selectorExpansion = '${scenario.selectorExpansion}'`)
       .evaluate(`window._backstopSelectors = '${scenario.selectors}'`)
       .evaluate(() => {
-
-
         if (window._selectorExpansion.toString() === 'true') {
           window._backstopSelectorsExp = window.expandSelectors(window._backstopSelectors);
         } else {

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -149,13 +149,15 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   }
   chromy.goto(url);
 
+  injectBackstopTools(chromy);
+
   //  --- WAIT FOR READY EVENT ---
   var readyEvent = scenario.readyEvent || config.readyEvent;
   if (readyEvent) {
     chromy
       .evaluate(`window._readyEvent = '${readyEvent}'`)
       .wait(_ => {
-        return window.hasLogged(window._readyEvent);
+        return window._backstopTools.hasLogged(window._readyEvent);
       })
       .evaluate(_ => console.info('readyEvent ok'));
   }
@@ -209,6 +211,8 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     }
   }
 
+  injectBackstopTools(chromy);
+
   // --- HIDE SELECTORS ---
   if (scenario.hasOwnProperty('hideSelectors')) {
     scenario.hideSelectors.forEach(function (selector) {
@@ -232,14 +236,12 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   }
 
   return new Promise((resolve, reject) => {
-    injectBackstopTools(chromy);
-
     chromy
       .evaluate(`window._selectorExpansion = '${scenario.selectorExpansion}'`)
       .evaluate(`window._backstopSelectors = '${scenario.selectors}'`)
       .evaluate(() => {
         if (window._selectorExpansion.toString() === 'true') {
-          window._backstopSelectorsExp = window.expandSelectors(window._backstopSelectors);
+          window._backstopSelectorsExp = window._backstopTools.expandSelectors(window._backstopSelectors);
         } else {
           window._backstopSelectorsExp = window._backstopSelectors;
         }
@@ -248,8 +250,8 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
         }
         window._backstopSelectorsExpMap = window._backstopSelectorsExp.reduce((acc, selector) => {
           acc[selector] = {
-            exists: window.exists(selector),
-            isVisible: window.isVisible(selector)
+            exists: window._backstopTools.exists(selector),
+            isVisible: window._backstopTools.isVisible(selector)
           };
           return acc;
         }, {});


### PR DESCRIPTION
Solves #541.

I would be glad if somebody could enlighten me why this works. 

Using chromy's `inject` method resulted in no joy at all. Don't get why. Worked in other cases for me.
Trying to do this via `chromy.on('Page.loadEventFired')...` also didn't work.
I guess because the first evaluations are using these methods before this event?