### PR TITLE
add engineOptions to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,14 @@ An example config below...
 
 ### Integration options (local install)
 
+TLDR; run the example here...
+```
+cd backstopjs/test/configs/
+node multi_step node_example
+```
+
+Details...
+
 Installing BackstopJS locally to your project makes a few integration options available.
 
 The most basic example probably looks like this....
@@ -546,13 +554,7 @@ npm install backstopjs
 ./node_modules/backstopjs/cli/index.js test --config=<myConfigPath>
 ```
 
-If you are going to call backstop from another app you will probably want to do something like this...
-
-```sh
-$ npm install backstopjs
-```
-
-Once installed you can require your local backstop installation into your project.
+If you are going to call backstop from another app you can import it into your project...
 
 ```js
 const backstop = require('backstopjs');
@@ -575,8 +577,22 @@ backstop('test', {config:'custom/backstop/config.json'});
 
 #### Pass a config object to the command
 ```js
-// you can also pass
+// you can also pass a literal object
 backstop('test', {
+  config: {
+    id: "foo",
+    scenarios: [
+      //some scenarios here
+    ]
+  }
+});
+```
+
+#### The `--filter` argument still works too -- just pass a `filter` prop instead.
+```js
+// you can also pass a literal object
+backstop('test', {
+  filter: 'someScenarioLabelAsRegExString',
   config: {
     id: "foo",
     scenarios: [

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ See casperjs documentation for more info on instance options.  An example config
 ### Setting Chromy option flags
 Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
 
-**Please note:**
+**Please note:** Backstop sets defaults for many Chromy properties. Setting a parameter value here will override any default value set by backstop.
 - Setting `port` is way not advised. 
 - Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
 

--- a/README.md
+++ b/README.md
@@ -513,9 +513,10 @@ See casperjs documentation for more info on instance options.  An example config
 ### Setting Chromy option flags
 Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
 
-**Please note:** Backstop sets defaults for many Chromy properties. Setting a parameter value here will override any default value set by backstop.
-- Setting `port` is way not advised. 
-- Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
+**NOTE:** Backstop sets defaults for many Chromy properties. Setting a parameter value with engineOptions will override any default value set by backstop. _But please watch out for the following..._
+- (TLDR) Setting `port` is _very_ _very_ not advised.
+- Setting `chromeFlags` will override all chromeFlags properties set by backstop -- **EXCEPT FOR `--window-size`***...  (i.e. `--window-size` flag will be added by backstop if not found in chromeFlags) 
+- Setting `--window-size` explicitly in `chromeFlags` will override values used in your viewport settings.
 
 
 An example config below...

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ The default port used by BackstopJS is 3001.   You can change it by setting the 
 -->
 
 ### Setting Casper command-line flags
-This is for you if for some reason you find yourself needing advanced configuration access to CasperJS.  You can set CasperJS flags via `casperFlags` like so...
+See casperjs documentation for more info on instance options.  An example config below...
 
 ```json
 "casperFlags": [
@@ -508,6 +508,24 @@ This is for you if for some reason you find yourself needing advanced configurat
   "--proxy=proxyIp:port",
   "--proxy-auth=user:pass"
 ]
+```
+
+### Setting Chromy option flags
+Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
+
+**Please note:**
+- Setting `port` is way not advised. 
+- Setting `--window-size` will override values used in your viewport settings.
+
+
+An example config below...
+
+```json
+"engineOptions": {
+  waitTimeout: 120000,
+  chromePath: /path/to/chrome,
+  chromeFlags: ['--disable-gpu', '--force-device-scale-factor=1']
+}
 ```
 
 ### Integration options (local install)

--- a/README.md
+++ b/README.md
@@ -515,12 +515,12 @@ Chromy enables a lot of behavior via constructor options.  See Chromy documentat
 
 **Please note:**
 - Setting `port` is way not advised. 
-- Setting `--window-size` will override values used in your viewport settings.
+- Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
 
 
 An example config below...
 
-```json
+```js
 "engineOptions": {
   waitTimeout: 120000,
   chromePath: /path/to/chrome,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ url                      // [required] The url of your app state
 referenceUrl             // Specify a different state or environment when creating reference.
 readyEvent               // Wait until this string has been logged to the console.
 readySelector            // Wait until this selector exists before continuing.
-delay                    // Wait for x millisections
+delay                    // Wait for x milliseconds
 hideSelectors            // Array of selectors set to visibility: hidden
 removeSelectors          // Array of selectors set to display: none
 onReadyScript            // After the above conditions are met -- use this script to modify UI state prior to screen shots e.g. hovers, clicks etc.
@@ -645,14 +645,14 @@ As a (very approximate) rule of thumb, BackstopJS will use 100MB RAM plus approx
 To adjust this value add the following to the root of your config...
 ```json
 "asyncCompareLimit": 100
-// Would require 600MB to run tests. Your milage most likely will vary ;)
+// Would require 600MB to run tests. Your mileage most likely will vary ;)
 ```
 
 ### Creating reference files
 This Utility command will by default delete all existing screen references and create new ones based on the `referenceUrl` or `url` config config. It will not run any file comparisons.
 
 Use this when you...
-- create references from another enviornment (e.g. staging vs prod)
+- create references from another environment (e.g. staging vs prod)
 - or clean out your reference files and start fresh with all new reference
 - or just create references without previewing
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ By default, BackstopJS saves generated resources into the `backstop_data` direct
 ```
 
 ### Changing the rendering engine
-BackstopJS supports using Chrome-Headless, PhantomJS or SlimerJS for web app rendering. PhantomJS is currently the default value and will be installed by default.
+BackstopJS supports using Chrome-Headless, PhantomJS or SlimerJS for web app rendering. Chrome-headless (chromy) is currently the default value and will be installed by default.
 
 #### Chrome-Headless (The latest webkit library)
 This will also enable the very cool _chromy.js_ (https://github.com/OnetapInc/chromy) library.  (When creating onBefore and onReady scripts please make sure you are referring to the [Chromy script documentation](https://github.com/OnetapInc/chromy).  Casper features will not work with this setting.)

--- a/capture/engine_scripts/onReady.js
+++ b/capture/engine_scripts/onReady.js
@@ -1,6 +1,6 @@
 module.exports = function (engine, scenario, vp) {
   engine.evaluate(function () {
-    // Your web-app is now loaded. Edit here to simulate user interacions or other state changes in the browser window context.
+    // Your web-app is now loaded. Edit here to simulate user interactions or other state changes in the browser window context.
   });
   console.log('onReady.js has run for: ', vp.label);
 };

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// --inspect-brk
 
 var parseArgs = require('minimist');
 var usage = require('./usage');

--- a/compare/bower_components/bootstrap-css-only/README.md
+++ b/compare/bower_components/bootstrap-css-only/README.md
@@ -1,6 +1,6 @@
 # Bootstrap CSS only
 
-A Bower and NPM component for [Bootstrap](http://getbootstrap.com/) CSS and font libraries only. No javascript, and more importantly NO depenedency on jQuery. Perfect companion for [Angular-UI Bootstrap](https://github.com/angular-ui/bootstrap-bower).
+A Bower and NPM component for [Bootstrap](http://getbootstrap.com/) CSS and font libraries only. No javascript, and more importantly NO dependency on jQuery. Perfect companion for [Angular-UI Bootstrap](https://github.com/angular-ui/bootstrap-bower).
 
 - With 3.0.1 and above, the glyphicons are included as well.
 - Starting with version 3.3.5, package is available on NPM also.

--- a/compare/js/revealer.js
+++ b/compare/js/revealer.js
@@ -133,11 +133,11 @@
 
             // when the handle is dragged, can either
             // be a 'mousemove' or 'touchmove' event,
-            // caluclate the position of the overlay
+            // calculate the position of the overlay
             $document.on(eventConfig.move, handleDrag);
 
             // when the release action is triggered unbind
-            // event listerners on drag an elements
+            // event listeners on drag an elements
             $document.on(eventConfig.release, removeListeners);
           });
         });
@@ -149,7 +149,7 @@
 
       /**
        * handle the drag of the handle, if the handle is
-       * draged outside the container do nothing. Otherwise
+       * dragged outside the container do nothing. Otherwise
        * calculate the percentage and set the position of
        * the handle and the width of the topImage container
        * @param  {Event Object} e : Event Object
@@ -182,7 +182,7 @@
         e.preventDefault();
 
         // calculate if elem in viewport
-        // if it is, calulate the scroll percentage
+        // if it is, calculate the scroll percentage
         // in relation to the elem, set percentage for revealer
         if (inView(elem, $window, scope.scrollOffset)) {
           var elemTop = getDimensions(elem[0].parentNode).top;
@@ -242,7 +242,7 @@
   }
 
   /**
-   * get the mouse coordsinatea based on a target element
+   * get the mouse coordinates based on a target element
    * @param  {Event object}  e
    * @param  {Object} target position of target element on page
    * @return {Object}        x and y coordinates of mouse
@@ -275,7 +275,7 @@
   /**
    * utility function to throttle the execution
    * of the callback, this is useful when every
-   * opertations need to be done on events that
+   * operations need to be done on events that
    * get executed in rapid succession. The callback
    * will get executed after the delay
    * @param  {Function} cb

--- a/core/command/approve.js
+++ b/core/command/approve.js
@@ -5,7 +5,7 @@ var map = require('p-map');
 var FAILED_DIFF_RE = /^failed_diff_/;
 var FILTER_DEFAULT = /\w+/;
 
-// This task will copy ALL test bitmap files (from the most recent test directory) to the reference directory overwritting any exisiting files.
+// This task will copy ALL test bitmap files (from the most recent test directory) to the reference directory overwriting any existing files.
 module.exports = {
   execute: function (config) {
     // TODO:  IF Exists config.bitmaps_test  &&  list.length > 0n  (otherwise throw)

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -70,7 +70,7 @@ var commands = commandNames
             return;
           }
           var perf = (new Date() - config.perf[command.name].started) / 1000;
-          logger.success('Command `' + command.name + '` sucessfully executed in [' + perf + 's]');
+          logger.success('Command `' + command.name + '` successfully executed in [' + perf + 's]');
           return result;
         });
       }

--- a/core/command/openReport.js
+++ b/core/command/openReport.js
@@ -15,7 +15,7 @@ module.exports = {
       logger.log('Opening report.');
       open(toAbsolute(config.compareReportURL), function (err) {
         if (err) {
-          logger.error('An error occured while opening report in the default browser.');
+          logger.error('An error occurred while opening report in the default browser.');
         }
         resolve();
       });

--- a/core/util/compare/compare.js
+++ b/core/util/compare/compare.js
@@ -1,7 +1,30 @@
 var compareHashes = require('./compare-hash');
 var compareResemble = require('./compare-resemble');
+var storeFailedDiff = require('./store-failed-diff.js');
 
-module.exports = function (referencePath, testPath, misMatchThreshold, resembleOutputSettings, requireSameDimensions) {
-  return compareHashes(referencePath, testPath)
-     .catch(() => compareResemble(referencePath, testPath, misMatchThreshold, resembleOutputSettings, requireSameDimensions));
+process.on('message', compare);
+
+function compare (data) {
+  var {referencePath, testPath, resembleOutputSettings, pair} = data;
+  var promise = compareHashes(referencePath, testPath)
+    .catch(() => compareResemble(referencePath, testPath, pair.misMatchThreshold, resembleOutputSettings, pair.requireSameDimensions));
+  promise
+    .then(function (data) {
+      pair.diff = data;
+      pair.status = 'pass';
+      return sendMessage(pair);
+    })
+    .catch(function (data) {
+      pair.diff = data;
+      pair.status = 'fail';
+
+      return storeFailedDiff(testPath, data).then(function (compare) {
+        pair.diffImage = compare;
+        return sendMessage(pair);
+      });
+    });
 };
+
+function sendMessage (data) {
+  process.send(data);
+}

--- a/core/util/createBitmaps.js
+++ b/core/util/createBitmaps.js
@@ -53,15 +53,15 @@ function decorateConfigForCapture (config, isReference) {
   configJSON.defaultRequireSameDimensions = config.defaultRequireSameDimensions;
 
   if (config.args.filter) {
-    var scenarii = [];
+    var scenarios = [];
     config.args.filter.split(',').forEach(function (filteredTest) {
       each(configJSON.scenarios, function (scenario) {
         if (regexTest(scenario.label, filteredTest)) {
-          scenarii.push(scenario);
+          scenarios.push(scenario);
         }
       });
     });
-    configJSON.scenarios = scenarii;
+    configJSON.scenarios = scenarios;
   }
 
   logger.log('Selected ' + configJSON.scenarios.length + ' of ' + totalScenarioCount + ' scenarios.');
@@ -70,7 +70,7 @@ function decorateConfigForCapture (config, isReference) {
 
 /**
  * Utility for generating a temporary config file required by GENERATE_BITMAPS_SCRIPT.
- * @config  {Object}        Base user config object (derrived by user config file + CL param overrides).
+ * @config  {Object}        Base user config object (derived by user config file + CL param overrides).
  * @isReference  {Boolean}  True if running reference flow.
  * @return {Promise}        Resolves when fs.writeFile has completed.
  */
@@ -82,7 +82,7 @@ function delegateScenarios (config) {
   var screenshotNow = new Date();
   var screenshotDateTime = screenshotNow.getFullYear() + pad(screenshotNow.getMonth() + 1) + pad(screenshotNow.getDate()) + '-' + pad(screenshotNow.getHours()) + pad(screenshotNow.getMinutes()) + pad(screenshotNow.getSeconds());
 
-  // TODO: start chromy here?  Or later?  maybe later because maybe changing resoloutions doesn't work after starting?
+  // TODO: start chromy here?  Or later?  maybe later because maybe changing resolutions doesn't work after starting?
   // casper.start();
 
   var scenarios = [];
@@ -184,8 +184,8 @@ module.exports = function (config, isReference) {
         console.log('\n' + result);
         // exit if there was some kind of failure in the casperChild process
         if (code !== 0) {
-          console.log('\nAn unexpected error occured. You may want to try setting the debug option to `true` in your config file.');
-          reject(new Error('An unexpected error occured. You may want to try setting the debug option to `true` in your config file.'));
+          console.log('\nAn unexpected error occurred. You may want to try setting the debug option to `true` in your config file.');
+          reject(new Error('An unexpected error occurred. You may want to try setting the debug option to `true` in your config file.'));
           return;
         }
         resolve();

--- a/core/util/createBitmaps.js
+++ b/core/util/createBitmaps.js
@@ -34,7 +34,7 @@ function decorateConfigForCapture (config, isReference) {
   if (typeof config.args.config === 'object') {
     configJSON = config.args.config;
   } else {
-    configJSON = require(config.backstopConfigFileName);
+    configJSON = Object.assign({}, require(config.backstopConfigFileName));
   }
   configJSON.scenarios = configJSON.scenarios || [];
   ensureViewportLabel(configJSON);

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -270,7 +270,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   // CREATE SCREEN SHOTS AND TEST COMPARE CONFIGURATION (CONFIG FILE WILL BE SAVED WHEN THIS PROCESS RETURNS)
   // this.echo('Capturing screenshots for ' + makeSafe(vp.name) + ' (' + (vp.width || vp.viewport.width) + 'x' + (vp.height || vp.viewport.height) + ')', 'info');
 
-  // --- HANDLE NO-SELCTORS ---
+  // --- HANDLE NO-SELECTORS ---
   if (!scenario.hasOwnProperty('selectors') || !scenario.selectors.length) {
     scenario.selectors = [DOCUMENT_SELECTOR];
   }
@@ -313,7 +313,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
         ));
       })
       .end()
-      // If an error occured then resolve with an error.
+      // If an error occurred then resolve with an error.
       .catch(e => resolve(new BackstopException('Chromy error', scenario, viewport, e)));
   });
 }

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -61,6 +61,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   const DEFAULT_CHROME_FLAGS = ['--disable-gpu', '--force-device-scale-factor=1', '--disable-infobars=true'];
   const PORT = CHROMY_STARTING_PORT_NUMBER + runId;
   let defaultOptions = {
+    chromeFlags: undefined,
     port: PORT,
     waitTimeout: TEST_TIMEOUT,
     visible: config.debugWindow || false
@@ -91,7 +92,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
 
   // if --window-size= has not been explicity set, then set it. (this is the expected case)
   if (!/--window-size=/i.test(chromyOptions.chromeFlags.toString())) {
-    chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
+    chromyOptions.chromeFlags = chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
   }
 
   console.log('Starting Chromy:', JSON.stringify(chromyOptions));

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -85,7 +85,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   let chromyOptions = Object.assign({}, defaultOptions, engineOptions);
 
   // if chromeFlags has not been explicitly set, then set it. (this is the expected case)
-  if (!chromyOptions.chromeFlags)
+  if (!chromyOptions.chromeFlags) {
     chromyOptions.chromeFlags = DEFAULT_CHROME_FLAGS;
   }
 
@@ -94,7 +94,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
   }
 
-  console.log('Starting Chromy:', `port:${PORT}`, flags.toString());
+  console.log('Starting Chromy:', JSON.stringify(chromyOptions));
   let chromy = new Chromy(chromyOptions).chain();
 
   /**

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -136,7 +136,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   // --- set up console output ---
   chromy.console(function (text, consoleObj) {
     if (console[consoleObj.level]) {
-      console[consoleObj.level](port + ' ' + (consoleObj.level).toUpperCase() + ' > ', text);
+      console[consoleObj.level](PORT + ' ' + (consoleObj.level).toUpperCase() + ' > ', text);
     }
   });
 
@@ -146,9 +146,9 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
       return v ? parseInt(v[2], 10) : 0;
     })
     .result(chromeVersion => {
-      console.info(`${port} Chrome v${chromeVersion} detected.`);
+      console.info(`${PORT} Chrome v${chromeVersion} detected.`);
       if (chromeVersion < MIN_CHROME_VERSION) {
-        console.warn(`${port} ***WARNING! CHROME VERSION ${MIN_CHROME_VERSION} OR GREATER IS REQUIRED. PLEASE UPDATE YOUR CHROME APP!***`);
+        console.warn(`${PORT} ***WARNING! CHROME VERSION ${MIN_CHROME_VERSION} OR GREATER IS REQUIRED. PLEASE UPDATE YOUR CHROME APP!***`);
       }
     });
 
@@ -172,7 +172,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     if (fs.existsSync(beforeScriptPath)) {
       require(beforeScriptPath)(chromy, scenario, viewport, isReference);
     } else {
-      console.warn(port, ' WARNING: script not found: ' + beforeScriptPath);
+      console.warn(PORT, ' WARNING: script not found: ' + beforeScriptPath);
     }
   }
 
@@ -212,9 +212,9 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   if (config.debug) {
     chromy
       .evaluate(_ => document.head.outerHTML)
-      .result(headStr => console.log(port + 'HEAD > ', headStr))
+      .result(headStr => console.log(PORT + 'HEAD > ', headStr))
       .evaluate(_ => document.body.outerHTML)
-      .result(htmlStr => console.log(port + 'BODY > ', htmlStr));
+      .result(htmlStr => console.log(PORT + 'BODY > ', htmlStr));
   }
 
   // --- REMOVE SELECTORS ---
@@ -247,7 +247,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     if (fs.existsSync(readyScriptPath)) {
       require(readyScriptPath)(chromy, scenario, viewport, isReference);
     } else {
-      console.warn(port, 'WARNING: script not found: ' + readyScriptPath);
+      console.warn(PORT, 'WARNING: script not found: ' + readyScriptPath);
     }
   }
 

--- a/examples/set cookies onBefore/backstop_data/casper_scripts/onReady.js
+++ b/examples/set cookies onBefore/backstop_data/casper_scripts/onReady.js
@@ -1,6 +1,6 @@
 module.exports = function (casper, scenario, vp) {
   casper.evaluate(function () {
-    // Your web-app is now loaded. Edit here to simulate user interacions or other state changes.
+    // Your web-app is now loaded. Edit here to simulate user interactions or other state changes.
   });
   console.log('onReady.js has run for: ', vp.name);
 };

--- a/examples/simpleReactApp/backstop_data/casper_scripts/onReady.js
+++ b/examples/simpleReactApp/backstop_data/casper_scripts/onReady.js
@@ -1,6 +1,6 @@
 module.exports = function (casper, scenario, vp) {
   casper.echo('onReady.js', 'INFO');
   casper.evaluate(function () {
-    console.log('Your web-app is now loaded. Modify onReady.js to simulate user interacions or other state changes.');
+    console.log('Your web-app is now loaded. Modify onReady.js to simulate user interactions or other state changes.');
   });
 };

--- a/old_splash_page_v2.0/index.html
+++ b/old_splash_page_v2.0/index.html
@@ -92,7 +92,7 @@
               <li>- Custom screenshot file naming</li>
               <li>- More bug fixes than you can shake a stick at</li>
               <li>- Removed Gulp dependency and more!</li>
-              <li> <strong>Check the documentation for new streamilined install instructions and config changes.</strong></li>
+              <li> <strong>Check the documentation for new streamlined install instructions and config changes.</strong></li>
             </ul>
         </p>
       </div>
@@ -114,7 +114,7 @@
           <h2>ONE</h2>
           <figure>
             <figcaption>
-              BackstopJS Creates reference screenshots of your webpage/web-app at multiple sceen sizes.
+              BackstopJS Creates reference screenshots of your webpage/web-app at multiple screen sizes.
             </figcaption>
             <img src="./img/one@2x.png" class="img-responsive" ></img>
           </figure>
@@ -194,7 +194,7 @@
       <div class="row finalWords">
         <div class="col-sm-12 ">
           <h2>
-            <a href="https://github.com/garris/BackstopJS">Installation, Documentation, Contributation!</a>
+            <a href="https://github.com/garris/BackstopJS">Installation, Documentation, Contribution!</a>
           </h2>
           <p>
             And while you're at it, <a href="http://tremulajs.org/">check out TremulaJS</a>, another fine project developed at Art.com labs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.0.29",
+  "version": "3.0.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "node ./cli/index.js test",
     "openReport": "node ./cli/index.js openReport",
     "echo": "node ./cli/index.js echo",
-    "unit-test": "mocha --reporter spec --recursive test/",
+    "unit-test": "mocha --reporter spec --recursive test/cli",
     "integration-test": "rm -rf newdir && mkdir newdir && cd newdir && node ../cli/index.js genConfig && node ../cli/index.js reference && node ../cli/index.js test && node -e \"require('../')('test')\""
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.0.29",
+  "version": "3.0.30",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/test/cli/usage_spec.js
+++ b/test/cli/usage_spec.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var expectedUsage = "Welcome to BackstopJS 2.1.4 CLI\n\
 \n\
 Commands:\n\
-    reference      Create reference screenshots of your web content at multiple sceen sizes.\n\
+    reference      Create reference screenshots of your web content at multiple screen sizes.\n\
     test           Create test screenshots of your web content and compare against the set you created using `backstop reference`.\n\
     genConfig      Generate a configuration file boilerplate in your current directory. PLEASE NOTE: this will force overwrite any existing config.\n\
     openReport     View your last test screenshots in your browser.\n\

--- a/test/configs/backstop_data/engine_scripts/onReady.js
+++ b/test/configs/backstop_data/engine_scripts/onReady.js
@@ -1,6 +1,6 @@
 module.exports = function (engine, scenario, vp) {
   engine.evaluate(function () {
-    // Your web-app is now loaded. Edit here to simulate user interacions or other state changes in the browser window context.
+    // Your web-app is now loaded. Edit here to simulate user interactions or other state changes in the browser window context.
   });
   console.log('onReady.js has run for: ', vp.label);
 };

--- a/test/configs/multi_step node_example.js
+++ b/test/configs/multi_step node_example.js
@@ -1,0 +1,86 @@
+var backstop = require('../../core/runner');
+
+console.log('Running a multi-step Backstop test. vvv');
+
+// this will run `backstop test` with default config file (./backstop.json in current directory)
+backstop('test')
+  .catch(approveChanges)
+  .then(() => {
+    // this invocation is equivalent to running `backstop test --config=backstop_features --filter=click`
+    return backstop('test', {
+      filter: 'click',
+      config: 'backstop_features'
+    });
+  })
+  .catch(approveChanges)
+  .then(() => {
+    // this invocation is equivalent to running `backstop test --filter=Delayed` on exampleConfig.
+    return backstop('test', exampleConfig);
+  })
+  .catch(approveChanges);
+
+/**
+ * run this to approve changes from the previous run.
+ */
+function approveChanges () {
+  console.log('Looks like there were some changes detected since last run.');
+  backstop('approve', {
+    config: {
+      id: 'explicity_defined',
+      paths: {
+        bitmaps_reference: 'backstop_data/bitmaps_reference',
+        bitmaps_test: 'backstop_data/bitmaps_test'
+      }
+    }
+  });
+}
+
+/**
+ * A config used to test explicity setting a config.
+ * @type {Object}
+ */
+const exampleConfig = {
+  filter: 'Delayed',
+  config: {
+    id: 'explicity_defined',
+    viewports: [
+      {
+        label: 'phone',
+        width: 320,
+        height: 480
+      },
+      {
+        label: 'tablet',
+        width: 1024,
+        height: 768
+      }
+    ],
+    onBeforeScript: 'chromy/onBefore.js',
+    onReadyScript: 'chromy/onReady.js',
+    scenarios: [
+      {
+        label: 'Homepage',
+        cookiePath: 'backstop_data/engine_scripts/cookies.json',
+        url: 'https://garris.github.io/BackstopJS/?delay'
+      },
+      {
+        label: 'Homepage Delayed',
+        cookiePath: 'backstop_data/engine_scripts/cookies.json',
+        url: 'https://garris.github.io/BackstopJS/?delay'
+      }
+    ],
+    paths: {
+      bitmaps_reference: 'backstop_data/bitmaps_reference',
+      bitmaps_test: 'backstop_data/bitmaps_test',
+      engine_scripts: 'backstop_data/engine_scripts',
+      html_report: 'backstop_data/html_report',
+      ci_report: 'backstop_data/ci_report'
+    },
+    report: ['browser'],
+    engine: 'chrome',
+    asyncCaptureLimit: 5,
+    asyncCompareLimit: 50,
+    debug: false,
+    debugWindow: false
+  }
+};

--- a/test/core/util/compare/compare-hash_spec.js
+++ b/test/core/util/compare/compare-hash_spec.js
@@ -20,7 +20,7 @@ describe('compare-hashes', function () {
   it('should reject if two images have the same content', function (cb) {
     compareHash(REF_IMG1, REF_IMG1_OPTIMIZED).catch(() => cb());
   });
-  it('should reject if two images exceed the missmatchThreshold', function (cb) {
+  it('should reject if two images exceed the mismatchThreshold', function (cb) {
     compareHash(REF_IMG1, REF_IMG2).catch(() => cb());
   });
 });

--- a/test/core/util/compare/compare-resemble_spec.js
+++ b/test/core/util/compare/compare-resemble_spec.js
@@ -12,7 +12,7 @@ describe('compare-resemble', function () {
     it('should resolve if two images have the same content', function () {
         return compareResemble(REF_IMG1, REF_IMG1_OPTIMIZED, 0, {});
     });
-    it('should reject if two images exceed the missmatchThreshold', function (cb) {
+    it('should reject if two images exceed the mismatchThreshold', function (cb) {
         compareResemble(REF_IMG1, REF_IMG2, 0, {}).catch(() => cb());
     });
 });


### PR DESCRIPTION
Enables setting/overriding of Chromy options.

**Please note:**
- Setting `port` is _very_ not advised.
- Setting `chromeFlags` will override all chromeFlags properties set by backstop -- EXCEPT FOR `--window-size`...  (`--window-size` flag will be added by backstop if not found in chromeFlags) 
- Setting `--window-size` explicitly in `chromeFlags` will override values used in your viewport settings.