### PR TITLE
Engine options update

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ See casperjs documentation for more info on instance options.  An example config
 ### Setting Chromy option flags
 Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
 
-**Please note:**
+**Please note:** Backstop sets defaults for many Chromy properties. Setting a parameter value here will override any default value set by backstop.
 - Setting `port` is way not advised. 
 - Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
 

--- a/README.md
+++ b/README.md
@@ -513,9 +513,10 @@ See casperjs documentation for more info on instance options.  An example config
 ### Setting Chromy option flags
 Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
 
-**Please note:** Backstop sets defaults for many Chromy properties. Setting a parameter value here will override any default value set by backstop.
-- Setting `port` is way not advised. 
-- Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
+**NOTE:** Backstop sets defaults for many Chromy properties. Setting a parameter value with engineOptions will override any default value set by backstop. _But please watch out for the following..._
+- (TLDR) Setting `port` is _very_ _very_ not advised.
+- Setting `chromeFlags` will override all chromeFlags properties set by backstop -- **EXCEPT FOR `--window-size`***...  (i.e. `--window-size` flag will be added by backstop if not found in chromeFlags) 
+- Setting `--window-size` explicitly in `chromeFlags` will override values used in your viewport settings.
 
 
 An example config below...

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ The default port used by BackstopJS is 3001.   You can change it by setting the 
 -->
 
 ### Setting Casper command-line flags
-This is for you if for some reason you find yourself needing advanced configuration access to CasperJS.  You can set CasperJS flags via `casperFlags` like so...
+See casperjs documentation for more info on instance options.  An example config below...
 
 ```json
 "casperFlags": [
@@ -508,6 +508,24 @@ This is for you if for some reason you find yourself needing advanced configurat
   "--proxy=proxyIp:port",
   "--proxy-auth=user:pass"
 ]
+```
+
+### Setting Chromy option flags
+Chromy enables a lot of behavior via constructor options.  See Chromy documentation for more info.  
+
+**Please note:**
+- Setting `port` is way not advised. 
+- Setting `--window-size` will override values used in your viewport settings.
+
+
+An example config below...
+
+```json
+"engineOptions": {
+  waitTimeout: 120000,
+  chromePath: /path/to/chrome,
+  chromeFlags: ['--disable-gpu', '--force-device-scale-factor=1']
+}
 ```
 
 ### Integration options (local install)

--- a/README.md
+++ b/README.md
@@ -515,12 +515,12 @@ Chromy enables a lot of behavior via constructor options.  See Chromy documentat
 
 **Please note:**
 - Setting `port` is way not advised. 
-- Setting `--window-size` will override values used in your viewport settings.
+- Setting `--window-size` in chromeFlags will override values used in your viewport settings. Not advised.
 
 
 An example config below...
 
-```json
+```js
 "engineOptions": {
   waitTimeout: 120000,
   chromePath: /path/to/chrome,

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// --inspect-brk
 
 var parseArgs = require('minimist');
 var usage = require('./usage');

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// --inspect-brk
 
 var parseArgs = require('minimist');
 var usage = require('./usage');

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -61,6 +61,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   const DEFAULT_CHROME_FLAGS = ['--disable-gpu', '--force-device-scale-factor=1', '--disable-infobars=true'];
   const PORT = CHROMY_STARTING_PORT_NUMBER + runId;
   let defaultOptions = {
+    chromeFlags: undefined,
     port: PORT,
     waitTimeout: TEST_TIMEOUT,
     visible: config.debugWindow || false
@@ -91,7 +92,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
 
   // if --window-size= has not been explicity set, then set it. (this is the expected case)
   if (!/--window-size=/i.test(chromyOptions.chromeFlags.toString())) {
-    chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
+    chromyOptions.chromeFlags = chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
   }
 
   console.log('Starting Chromy:', JSON.stringify(chromyOptions));

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -92,7 +92,8 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
 
   // if --window-size= has not been explicity set, then set it. (this is the expected case)
   if (!/--window-size=/i.test(chromyOptions.chromeFlags.toString())) {
-    chromyOptions.chromeFlags = chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
+    chromyOptions.chromeFlags = chromyOptions.chromeFlags.concat('--window-size=' + VP_W + ',' + VP_H + '');
+    // chromyOptions.chromeFlags = chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
   }
 
   console.log('Starting Chromy:', JSON.stringify(chromyOptions));

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -85,7 +85,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   let chromyOptions = Object.assign({}, defaultOptions, engineOptions);
 
   // if chromeFlags has not been explicitly set, then set it. (this is the expected case)
-  if (!chromyOptions.chromeFlags)
+  if (!chromyOptions.chromeFlags) {
     chromyOptions.chromeFlags = DEFAULT_CHROME_FLAGS;
   }
 
@@ -94,7 +94,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     chromyOptions.chromeFlags.concat(`--window-size=${VP_W},${VP_H}`);
   }
 
-  console.log('Starting Chromy:', `port:${PORT}`, flags.toString());
+  console.log('Starting Chromy:', JSON.stringify(chromyOptions));
   let chromy = new Chromy(chromyOptions).chain();
 
   /**

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -136,7 +136,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   // --- set up console output ---
   chromy.console(function (text, consoleObj) {
     if (console[consoleObj.level]) {
-      console[consoleObj.level](port + ' ' + (consoleObj.level).toUpperCase() + ' > ', text);
+      console[consoleObj.level](PORT + ' ' + (consoleObj.level).toUpperCase() + ' > ', text);
     }
   });
 
@@ -146,9 +146,9 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
       return v ? parseInt(v[2], 10) : 0;
     })
     .result(chromeVersion => {
-      console.info(`${port} Chrome v${chromeVersion} detected.`);
+      console.info(`${PORT} Chrome v${chromeVersion} detected.`);
       if (chromeVersion < MIN_CHROME_VERSION) {
-        console.warn(`${port} ***WARNING! CHROME VERSION ${MIN_CHROME_VERSION} OR GREATER IS REQUIRED. PLEASE UPDATE YOUR CHROME APP!***`);
+        console.warn(`${PORT} ***WARNING! CHROME VERSION ${MIN_CHROME_VERSION} OR GREATER IS REQUIRED. PLEASE UPDATE YOUR CHROME APP!***`);
       }
     });
 
@@ -172,7 +172,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     if (fs.existsSync(beforeScriptPath)) {
       require(beforeScriptPath)(chromy, scenario, viewport, isReference);
     } else {
-      console.warn(port, ' WARNING: script not found: ' + beforeScriptPath);
+      console.warn(PORT, ' WARNING: script not found: ' + beforeScriptPath);
     }
   }
 
@@ -212,9 +212,9 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   if (config.debug) {
     chromy
       .evaluate(_ => document.head.outerHTML)
-      .result(headStr => console.log(port + 'HEAD > ', headStr))
+      .result(headStr => console.log(PORT + 'HEAD > ', headStr))
       .evaluate(_ => document.body.outerHTML)
-      .result(htmlStr => console.log(port + 'BODY > ', htmlStr));
+      .result(htmlStr => console.log(PORT + 'BODY > ', htmlStr));
   }
 
   // --- REMOVE SELECTORS ---
@@ -247,7 +247,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
     if (fs.existsSync(readyScriptPath)) {
       require(readyScriptPath)(chromy, scenario, viewport, isReference);
     } else {
-      console.warn(port, 'WARNING: script not found: ' + readyScriptPath);
+      console.warn(PORT, 'WARNING: script not found: ' + readyScriptPath);
     }
   }
 


### PR DESCRIPTION
Setting an engine parameter value with engineOptions will override any default value set by backstop. 

- (TLDR) Setting `port` is _very_ _very_ not advised.
- Setting `chromeFlags` will override all chromeFlags properties set by backstop -- **EXCEPT FOR `--window-size`***...  (i.e. `--window-size` flag will be added by backstop if not found in chromeFlags) 
- Setting `--window-size` explicitly in `chromeFlags` will override values used in your viewport settings.