### PR TITLE
fix show misMatchPercentage

### DIFF
--- a/core/util/compare/index.js
+++ b/core/util/compare/index.js
@@ -63,7 +63,7 @@ function compareImages (referencePath, testPath, pair, resembleOutputSettings, T
 
       if (data.status == 'fail') {
         pair.diffImage = data.diffImage;
-        logger.error('ERROR { requireSameDimensions: ' + (data.requireSameDimensions ? 'true' : 'false') + ', size: ' + (data.isSameDimensions ? 'ok' : 'isDifferent') + ', content: ' + data.misMatchPercentage + '%, threshold: ' + pair.misMatchThreshold + '% }: ' + pair.label + ' ' + pair.fileName);
+        logger.error('ERROR { requireSameDimensions: ' + (data.requireSameDimensions ? 'true' : 'false') + ', size: ' + (data.isSameDimensions ? 'ok' : 'isDifferent') + ', content: ' + data.diff.misMatchPercentage + '%, threshold: ' + pair.misMatchThreshold + '% }: ' + pair.label + ' ' + pair.fileName);
       } else {
         logger.success('OK: ' + pair.label + ' ' + pair.fileName);
       }


### PR DESCRIPTION
`content` is undefiened in cli report.

>   compare | ERROR { requireSameDimensions: true, size: isDifferent, content: undefined%, threshold: 0.1% }: 

fixed in this pull request.