### PR TITLE
Access to static Chromy functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,21 @@ An example config below...
 }
 ```
 
+### Using Chromy static functions
+To access use of Chromys static functions (such as addCustomDevice) the static chromy reference is sent as the fifth parameter to your onBefore/onReady scripts.
+
+Example usage:
+
+```
+module.exports = function (chromy, scenario, vp, isReference, chromyStatic) {
+	if(vp.label === "phone") {
+		chromyStatic.addCustomDevice({ name: "some-phone", /.../ });
+		chromy.emulate("some-phone");
+	}	
+}
+```
+For more info, see the [Chromy script documentation](https://github.com/OnetapInc/chromy).
+
 ### Integration options (local install)
 
 TLDR; run the example here...

--- a/README.md
+++ b/README.md
@@ -536,10 +536,10 @@ Example usage:
 
 ```
 module.exports = function (chromy, scenario, vp, isReference, chromyStatic) {
-	if(vp.label === "phone") {
-		chromyStatic.addCustomDevice({ name: "some-phone", /.../ });
-		chromy.emulate("some-phone");
-	}	
+  if(vp.label === "phone") {
+    chromyStatic.addCustomDevice({ name: "some-phone", /.../ });
+    chromy.emulate("some-phone");
+  }	
 }
 ```
 For more info, see the [Chromy script documentation](https://github.com/OnetapInc/chromy).

--- a/core/command/index.js
+++ b/core/command/index.js
@@ -62,7 +62,7 @@ var commands = commandNames
         promise.catch(function (error) {
           var perf = (new Date() - config.perf[command.name].started) / 1000;
           logger.error('Command `' + command.name + '` ended with an error after [' + perf + 's]');
-          // logger.error(error);
+          logger.error(error);
         });
 
         return promise.then(function (result) {

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -27,11 +27,6 @@ module.exports = function (args) {
   const runId = args.id;
   const scenarioLabelSafe = makeSafe(scenario.label);
   const variantOrScenarioLabelSafe = scenario._parent ? makeSafe(scenario._parent.label) : scenarioLabelSafe;
-
-  if(viewport.emulate) {
-    console.log('##### Adding custom device: ' + viewport.emulate.name + ' #####');
-    Chromy.addCustomDevice(viewport.emulate);
-  }
   
   return processScenarioView(scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, runId);
 };
@@ -104,10 +99,6 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
 
   console.log('Starting Chromy:', JSON.stringify(chromyOptions));
   let chromy = new Chromy(chromyOptions).chain();
-  if(viewport.emulate) {
-    console.log('##### Emulating as ' + viewport.emulate.name + ' #####');
-    chromy.emulate(viewport.emulate.name);
-  }
 
   /**
    * =================
@@ -181,7 +172,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   if (onBeforeScript) {
     var beforeScriptPath = path.resolve(engineScriptsPath, onBeforeScript);
     if (fs.existsSync(beforeScriptPath)) {
-      require(beforeScriptPath)(chromy, scenario, viewport, isReference);
+      require(beforeScriptPath)(chromy, scenario, viewport, isReference, Chromy);
     } else {
       console.warn(PORT, ' WARNING: script not found: ' + beforeScriptPath);
     }
@@ -256,7 +247,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   if (onReadyScript) {
     var readyScriptPath = path.resolve(engineScriptsPath, onReadyScript);
     if (fs.existsSync(readyScriptPath)) {
-      require(readyScriptPath)(chromy, scenario, viewport, isReference);
+      require(readyScriptPath)(chromy, scenario, viewport, isReference, Chromy);
     } else {
       console.warn(PORT, 'WARNING: script not found: ' + readyScriptPath);
     }

--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -27,6 +27,12 @@ module.exports = function (args) {
   const runId = args.id;
   const scenarioLabelSafe = makeSafe(scenario.label);
   const variantOrScenarioLabelSafe = scenario._parent ? makeSafe(scenario._parent.label) : scenarioLabelSafe;
+
+  if(viewport.emulate) {
+    console.log('##### Adding custom device: ' + viewport.emulate.name + ' #####');
+    Chromy.addCustomDevice(viewport.emulate);
+  }
+  
   return processScenarioView(scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, runId);
 };
 
@@ -98,6 +104,10 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
 
   console.log('Starting Chromy:', JSON.stringify(chromyOptions));
   let chromy = new Chromy(chromyOptions).chain();
+  if(viewport.emulate) {
+    console.log('##### Emulating as ' + viewport.emulate.name + ' #####');
+    chromy.emulate(viewport.emulate.name);
+  }
 
   /**
    * =================


### PR DESCRIPTION
- Access to static chromy reference in onBefore/onReady scripts. Example usage in README.md.
- Core: Always log out error messages.

Related to: https://github.com/garris/BackstopJS/issues/608