### PR TITLE
Fixing Docker build issues. Updated chrome, Potentially fixing issues #603 #537.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:8.5.0-alpine
+FROM node:8.5.0
 
 ARG BACKSTOPJS_VERSION
 
 ENV \
-	PHANTOMJS_VERSION=2.1.1 \
+	PHANTOMJS_VERSION=2.1.7 \
 	CASPERJS_VERSION=1.1.4 \
 	SLIMERJS_VERSION=0.10.3 \
 	BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION \
@@ -12,69 +12,21 @@ ENV \
 	NPM_CONFIG_UNSAFE_PERM=true
 
 # Base packages
-RUN apk add --no-cache \
-	bash \
-	curl \
-	python \
-	# Use GNU grep to avoid compatibility issues (busybox grep uses -r vs -R)
-	grep
+RUN apt-get update && \
+	apt-get install -y git sudo software-properties-common python-software-properties
 
-# Installing dependencies from archives - not only this allows us to control versions,
-# but the resulting image size is 130MB+ less (!) compared to an npm install (440MB vs 575MB).
-RUN \
-	mkdir -p /opt && \
-	# PhantomJS
-	echo "Downloading PhantomJS v${PHANTOMJS_VERSION}..." && \
-	curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx && \
-	mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /opt/phantomjs && \
-	ln -s /opt/phantomjs/bin/phantomjs /usr/bin/phantomjs && \
-	echo "Fixing PhantomJS on Alpine" && \
-	curl -sL "https://github.com/dustinblackman/phantomized/releases/download/${PHANTOMJS_VERSION}/dockerized-phantomjs.tar.gz" | tar zx -C /
+RUN sudo npm install -g --unsafe-perm=true --allow-root phantomjs@${PHANTOMJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root casperjs@${CASPERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root slimerjs@${SLIMERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}
 
-RUN \
-	# CasperJS
-	echo "Downloading CasperJS v${CASPERJS_VERSION}..." && \
-	curl -sL "https://github.com/casperjs/casperjs/archive/${CASPERJS_VERSION}.tar.gz" | tar zx && \
-	mv casperjs-${CASPERJS_VERSION} /opt/casperjs && \
-	ln -s /opt/casperjs/bin/casperjs /usr/bin/casperjs
+RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
+RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
 
-RUN \
-	# SlimerJS
-	echo "Downloading SlimerJS v${SLIMERJS_VERSION}..." && \
-	curl -sL -O "http://download.slimerjs.org/releases/${SLIMERJS_VERSION}/slimerjs-${SLIMERJS_VERSION}.zip" && \
-	unzip -q slimerjs-${SLIMERJS_VERSION}.zip && rm -f slimerjs-${SLIMERJS_VERSION}.zip && \
-	mv slimerjs-${SLIMERJS_VERSION} /opt/slimerjs && \
-	# Run slimer with xvfb
-	echo '#!/usr/bin/env bash\nxvfb-run /opt/slimerjs/slimerjs "$@"' > /opt/slimerjs/slimerjs.sh && \
-	chmod +x /opt/slimerjs/slimerjs.sh && \
-	ln -s /opt/slimerjs/slimerjs.sh /usr/bin/slimerjs
+RUN	apt-get -y update && \
+	apt-get -y install google-chrome-stable
 
-RUN \
-	# BackstopJS
-	echo "Installing BackstopJS v${BACKSTOPJS_VERSION}..." && \
-	npm install -g backstopjs@${BACKSTOPJS_VERSION}
-
-ENV \
-	CHROMIUM_VERSION=61.0 \
-	FIREFOX_VERSION=52.3 \
-	CHROME_PATH=/usr/bin/chromium-browser
-
-# Chrome (from edge)
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
-	"chromium>${CHROMIUM_VERSION}"
-
-# Firefox (from edge)
-RUN apk add --no-cache \
-	"firefox-esr>${FIREFOX_VERSION}"
-
-# SlimerJS dependencies
-RUN \
-	apk add --no-cache \
-	dbus \
-	xvfb
-
-# xvfb wrapper
-COPY xvfb-run /usr/bin/xvfb-run
+RUN apt-get install -y firefox-esr
 
 WORKDIR /src
 


### PR DESCRIPTION
I wanted to use Chrome and the latest version of BackstopJS using Docker. However the automatic build of BackstopJS isn't working.

This PR fixes the docker build error and updates PhantomJS and Chrome. In order to run on the latest stable Chrome 64 build, I had to change the original alpine base image to the default node image. This potentially fixies the memory leak issues reported in #603 #537 

You can test it out on: https://hub.docker.com/r/iain17/backstopjs/