### PR TITLE
Adds option to pass additional args to puppeteer.

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -56,7 +56,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
       ignoreHTTPSErrors: true,
       headless: !!!config.debugWindow
     },
-    config.puppeteerArgs
+    config.engineOptions
   );
 
   const browser = await puppeteer.launch(puppeteerArgs);

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -50,7 +50,16 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
   const VP_W = viewport.width || viewport.viewport.width;
   const VP_H = viewport.height || viewport.viewport.height;
 
-  const browser = await puppeteer.launch({ignoreHTTPSErrors: true, headless: !!!config.debugWindow});
+  const puppeteerArgs = Object.assign(
+    {},
+    {
+      ignoreHTTPSErrors: true,
+      headless: !!!config.debugWindow
+    },
+    config.puppeteerArgs
+  );
+
+  const browser = await puppeteer.launch(puppeteerArgs);
   const page = await browser.newPage();
 
   page.setViewport({width: VP_W, height: VP_H});


### PR DESCRIPTION
This refers mostly to
https://github.com/GoogleChrome/puppeteer/issues/2161 which I can not
solve unless I pass --no-sandbox and --disable-setuid-sandbox to
puppeteer.

The correct syntax for the backstop.json config would then be (specifically for my use case, as an example):

`"engine": "puppet",`
`"puppeteerArgs": {args: ['--no-sandbox', '--disable-setuid-sandbox']},`