### PR TITLE
hover always the center of the element

### DIFF
--- a/capture/engine_scripts/chromy/clickAndHoverHelper.js
+++ b/capture/engine_scripts/chromy/clickAndHoverHelper.js
@@ -8,7 +8,7 @@ module.exports = function (chromy, scenario) {
       .wait(hoverSelector)
       .rect(hoverSelector)
       .result(function (rect) {
-        chromy.mouseMoved(rect.left, rect.top);
+        chromy.mouseMoved(rect.left + rect.width/2, rect.top + rect.height/2);
       });
   }
 


### PR DESCRIPTION
I would love to see that the engine_script always hover the center of an element. There are sometimes margins, paddings, wrappers that doesn't work well with hovering.