### PR TITLE
Adding peerDependencies for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "path": "^0.12.7",
     "phantomjs-prebuilt": "^2.1.7",
     "puppeteer": "^1.2.0-next.1523485686787",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "react-modal": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-sticky": "^6.0.1",
@@ -93,5 +91,9 @@
     "temp": "^0.8.3",
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.7.1"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   }
 }


### PR DESCRIPTION
Moves react to peer dependency to prevent hard link and multiple react version installs.