### PR TITLE
Adding peer dependencies and dev dependencies for react and react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9103,6 +9103,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -9113,7 +9114,8 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "path": "^0.12.7",
     "phantomjs-prebuilt": "^2.1.7",
     "puppeteer": "^1.2.0-next.1523485686787",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "react-modal": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-sticky": "^6.0.1",
@@ -93,5 +91,9 @@
     "temp": "^0.8.3",
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.7.1"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "license": "MIT",
   "main": "core/runner.js",
   "devDependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "assert": "^1.4.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
Moves react to peer dependency to prevent hard link and multiple react version installs.
Local development supported by adding dev dependency on react and react-dom.