### PR TITLE
Puppeteer fix for creating blank (off page) screenshots

### DIFF
--- a/compare/src/components/App.js
+++ b/compare/src/components/App.js
@@ -13,7 +13,7 @@ const Wrapper = styled.section`
 `;
 
 export default class App extends React.Component {
-  render() {
+  render () {
     return (
       <StickyContainer>
         <Header />

--- a/compare/src/reducers/scrubber.js
+++ b/compare/src/reducers/scrubber.js
@@ -1,4 +1,4 @@
-function getPosFromImgId(imgId) {
+function getPosFromImgId (imgId) {
   switch (imgId) {
     case 'refImage':
       return 100;

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -362,8 +362,9 @@ async function captureScreenshot (page, browser, selector, selectorMap, config, 
       if (el) {
         const box = await el.boundingBox();
         if (box) {
-          await el.screenshot({
-            path: path
+          await page.screenshot({
+            path: path,
+            clip: box
           });
         } else {
           console.log(chalk.yellow(`Element not visible for capturing: ${s}`));

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:8.5.0
 
-ARG BACKSTOPJS_VERSION
+#ARG BACKSTOPJS_VERSION
 
 ENV \
 	PHANTOMJS_VERSION=2.1.7 \
 	CASPERJS_VERSION=1.1.4 \
 	SLIMERJS_VERSION=0.10.3 \
-	BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION \
+#	BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION \
 	# Workaround to fix phantomjs-prebuilt installation errors
 	# See https://github.com/Medium/phantomjs/issues/707
 	NPM_CONFIG_UNSAFE_PERM=true
@@ -18,7 +18,7 @@ RUN apt-get update && \
 RUN sudo npm install -g --unsafe-perm=true --allow-root phantomjs@${PHANTOMJS_VERSION}
 RUN sudo npm install -g --unsafe-perm=true --allow-root casperjs@${CASPERJS_VERSION}
 RUN sudo npm install -g --unsafe-perm=true --allow-root slimerjs@${SLIMERJS_VERSION}
-RUN sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root "git+ssh://git@github.com:cactusa/BackstopJS.git#v3.2.17-beta"
 
 RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
 RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:8.5.0
 
-#ARG BACKSTOPJS_VERSION
+ARG BACKSTOPJS_VERSION
 
 ENV \
 	PHANTOMJS_VERSION=2.1.7 \
 	CASPERJS_VERSION=1.1.4 \
 	SLIMERJS_VERSION=0.10.3 \
-#	BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION \
+	BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION \
 	# Workaround to fix phantomjs-prebuilt installation errors
 	# See https://github.com/Medium/phantomjs/issues/707
 	NPM_CONFIG_UNSAFE_PERM=true
@@ -18,7 +18,7 @@ RUN apt-get update && \
 RUN sudo npm install -g --unsafe-perm=true --allow-root phantomjs@${PHANTOMJS_VERSION}
 RUN sudo npm install -g --unsafe-perm=true --allow-root casperjs@${CASPERJS_VERSION}
 RUN sudo npm install -g --unsafe-perm=true --allow-root slimerjs@${SLIMERJS_VERSION}
-RUN sudo npm install -g --unsafe-perm=true --allow-root "git+ssh://git@github.com:cactusa/BackstopJS.git#v3.2.17-beta"
+RUN sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}
 
 RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
 RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.2.17",
+  "version": "3.2.17-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.2.17-beta",
+  "version": "3.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "p-map": "^1.1.1",
     "path": "^0.12.7",
     "phantomjs-prebuilt": "^2.1.7",
-    "puppeteer": "^1.2.0-next.1523485686787",
+    "puppeteer": "^1.4.0",
     "react-modal": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-sticky": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.2.17",
+  "version": "3.2.17-beta",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "p-map": "^1.1.1",
     "path": "^0.12.7",
     "phantomjs-prebuilt": "^2.1.7",
-    "puppeteer": "^1.4.0",
+    "puppeteer": "^1.1.1",
     "react-modal": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-sticky": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.2.17-beta",
+  "version": "3.2.18",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "p-map": "^1.1.1",
     "path": "^0.12.7",
     "phantomjs-prebuilt": "^2.1.7",
-    "puppeteer": "^1.1.1",
+    "puppeteer": "^1.2.0-next.1523485686787",
     "react-modal": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-sticky": "^6.0.1",


### PR DESCRIPTION
Details of the issue can be found in this issue https://github.com/garris/BackstopJS/issues/704

Ran lint which produced two changes that only add an empty spaces ... meh.

My change is tiny and is to do with the way we use puppeteer to make screenshots of specific elements on a page. So instead of using the element.screenshot() function to directly take a screenshot of the selected element, I have used page.screenshot() and provided the boundingBox object of the element as reference for the location of the element on the page. For some reason this way produces the expected screenshots. I am surprised it doesn't just work the way it was implemented, because in puppeteer's API documentation they claim that element.screenshot() essentially uses page.screenshot underneath ... weird.

@garris I have run the some tests and I am getting some failures. Thing is that the reference images for the tests that fail look a bit wrong, so I'm not sure what to do. Shall you commit image changes for the smoke tests as well?
