### PR TITLE
Readme - consistently name the example of required backstop

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,10 +689,10 @@ module.exports = options => {
 #### Since the backstop returns promises so it can run natively as a task in build systems like gulp
 ```js
 const gulp = require('gulp');
-const backstopjs = require('backstopjs');
+const backstop = require('backstopjs');
 
-gulp.task('backstop_reference', () => backstopjs('reference'));
-gulp.task('backstop_test', () => backstopjs('test'));
+gulp.task('backstop_reference', () => backstop('reference'));
+gulp.task('backstop_test', () => backstop('test'));
 ```
 
 #### Using npm run scripts


### PR DESCRIPTION
In the integration example the required var name is `backstopjs`, but in 2 other locations in the readme it's `backstop`. This change will make the naming consistent, since there's no reason for the difference.