### PR TITLE
docs(readme): add windows instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,9 @@ Working directory is expected to be mounted at `/src` in the container.
 ```
 $ docker run --rm -v $(pwd):/src backstopjs/backstopjs --version
 BackstopJS v3.x.x
+
+# On Windows use:
+$(pwd -W)
 ```
 
 You can also add a shell alias (in `.bashrc`, `.zshrc`, etc.) for convenience.


### PR DESCRIPTION
Need to change the `pwd` command to `pwd -W` to work on windows (when using git bash).