### PR TITLE
Fix test command when using docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to this project
+
+## Test
+
+```sh
+npm run genConfig
+npm run reference
+npm run test
+```

--- a/core/command/reference.js
+++ b/core/command/reference.js
@@ -1,30 +1,12 @@
-var createBitmaps = require('../util/createBitmaps');
-var fs = require('../util/fs');
-var logger = require('../util/logger')('clean');
+const createBitmaps = require('../util/createBitmaps');
+const fs = require('../util/fs');
+const logger = require('../util/logger')('clean');
+const { shouldRunDocker, runDocker } = require('../util/runDocker');
 
 module.exports = {
   execute: function (config) {
-    if (config.args.docker) {
-        const passAlongArgs = process.argv
-                    .slice(3)
-                    .join(' ')
-                    .replace(/--docker/, '--moby');
-
-        const DOCKER_TEST = `docker run --rm -it --mount type=bind,source="$(pwd)",target=/src backstopjs/backstopjs reference ${passAlongArgs}`;
-        const { spawn } = require('child_process');
-        console.log('Delegating command to Docker...', DOCKER_TEST)
-
-    return new Promise((resolve, reject) => {   
-      const dockerProcess = spawn(DOCKER_TEST, {stdio: 'inherit', shell: true});
-      dockerProcess.on('exit', function (code, signal) {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject('');
-        }
-      });
-    });
-
+    if (shouldRunDocker(config)) {
+      return runDocker(config, 'reference');
     } else {
       var firstStep;
       // do not remove reference directory if we are in incremental mode

--- a/core/command/test.js
+++ b/core/command/test.js
@@ -1,35 +1,18 @@
-var createBitmaps = require('../util/createBitmaps');
+const createBitmaps = require('../util/createBitmaps');
+const { shouldRunDocker, runDocker } = require('../util/runDocker');
 
 // This task will generate a date-named directory with DOM screenshot files as specified in `./capture/config.json` followed by running a report.
 // NOTE: If there is no bitmaps_reference directory or if the bitmaps_reference directory is empty then a new batch of reference files will be generated in the bitmaps_reference directory.  Reporting will be skipped in this case.
 module.exports = {
   execute: function (config) {
-	const executeCommand = require('./index');
-  	if (config.args.docker) {
-	    const passAlongArgs = process.argv
-	                .slice(3)
-	                .join(' ')
-	                .replace(/--docker/, '--moby');
-
-	    const DOCKER_TEST = `docker run --rm -it --mount type=bind,source="$(pwd)",target=/src backstopjs/backstopjs reference ${passAlongArgs}`;
-	    const { spawn } = require('child_process');
-	    console.log('Delegating command to Docker...', DOCKER_TEST)
-
-		return new Promise((resolve, reject) => {		
-			const dockerProcess = spawn(DOCKER_TEST, {stdio: 'inherit', shell: true});
-			dockerProcess.on('exit', function (code, signal) {
-				if (code === 0) {
-					resolve();
-				} else {
-					reject('');
-				}
-			});
-		}).finally(() => executeCommand('_openReport', config));
-
-  	} else {
-	    return createBitmaps(config, false).then(function () {
-	      return executeCommand('_report', config);
-	    });
-  	}
+    const executeCommand = require('./index');
+    if (shouldRunDocker(config)) {
+      return runDocker(config, 'test')
+        .finally(() => executeCommand('_openReport', config));
+    } else {
+      return createBitmaps(config, false).then(function () {
+        return executeCommand('_report', config);
+      });
+    }
   }
 };

--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -1,0 +1,25 @@
+module.exports.shouldRunDocker = (config) => config.args.docker;
+
+module.exports.runDocker = (config, backstopCommand) => {
+  if (config.args.docker) {
+    const passAlongArgs = process.argv
+                  .slice(3)
+                  .join('" "') // in case of spaces in a command
+                  .replace(/--docker/, '--moby');
+
+    const DOCKER_COMMAND = `docker run --rm -it --mount type=bind,source="${process.cwd()}",target=/src backstopjs/backstopjs ${backstopCommand} "${passAlongArgs}"`;
+    const { spawn } = require('child_process');
+    console.log('Delegating command to Docker...', DOCKER_COMMAND);
+
+    return new Promise((resolve, reject) => {
+      const dockerProcess = spawn(DOCKER_COMMAND, {stdio: 'inherit', shell: true});
+      dockerProcess.on('exit', function (code, signal) {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject('');
+        }
+      });
+    });
+  }
+};


### PR DESCRIPTION
- `backstop test --docker` was actually running `reference` instead. Fixed that and did a bit of refactoring so there's less copied and pasted code. 
- If you have spaces in a command it now adds quotes around it when passing through to Docker. E.g. `backstop test --docker --filter="some test"`.
- Now `--docker` will work on window as I'm using `${process.cwd()}` instead of `$(pwd)` in the docker command.
- Also added a `CONTRIBUTING.md` guide. It's a start. I couldn't figure out what commands to run and such to test my changes. Had to dig through the `package.json > scripts`. I think it could help others too.