### PR TITLE
Docker support on configuration file

### DIFF
--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -22,6 +22,11 @@ function extendConfig (config, userConfig) {
   config.resembleOutputOptions = userConfig.resembleOutputOptions;
   config.asyncCompareLimit = userConfig.asyncCompareLimit;
   config.backstopVersion = version;
+
+  if (userConfig.docker) {
+    config.args['docker'] = true;
+  }
+
   return config;
 }
 


### PR DESCRIPTION
With this PR, user can run with docker by adding `docker: true` on configuration file. I don't know if this is the best solution but it worked for me. 

@garris The only difference between running with `--docker` and `docker: true` is this:

```js
const passAlongArgs = process.argv
                  .slice(3)
                  .join('" "') // in case of spaces in a command
                  .replace(/--docker/, '--moby');
```
The `DOCKER_COMMAND` will be without `--moby`. Should I be worried about this?

fixes https://github.com/garris/BackstopJS/issues/834