### PR TITLE
Docker volumes are enough

### DIFF
--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -17,7 +17,7 @@ module.exports.runDocker = (config, backstopCommand) => {
       configArgs = configArgs.replace(/--docker/, '--moby');
     }
 
-    const DOCKER_COMMAND = `docker run --rm -t -v /src:${process.cwd()} backstopjs/backstopjs ${backstopCommand}${configArgs} "${passAlongArgs}"`;
+    const DOCKER_COMMAND = `docker run --rm -t -v ${process.cwd()}:/src backstopjs/backstopjs ${backstopCommand}${configArgs} "${passAlongArgs}"`;
     const { spawn } = require('child_process');
     console.log('Delegating command to Docker...', DOCKER_COMMAND);
 

--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -17,7 +17,7 @@ module.exports.runDocker = (config, backstopCommand) => {
       configArgs = configArgs.replace(/--docker/, '--moby');
     }
 
-    const DOCKER_COMMAND = `docker run --rm -it --mount type=bind,source="${process.cwd()}",target=/src backstopjs/backstopjs ${backstopCommand}${configArgs} "${passAlongArgs}"`;
+    const DOCKER_COMMAND = `docker run --rm -t -v /src:${process.cwd()} backstopjs/backstopjs ${backstopCommand}${configArgs} "${passAlongArgs}"`;
     const { spawn } = require('child_process');
     console.log('Delegating command to Docker...', DOCKER_COMMAND);
 


### PR DESCRIPTION
In our use case using a volume instead of a mount is much better:

- `mount` is available only from Docker version 17.06, while `volume` is available since ancient Docker times
- We don't need to assert that `/src` exists on the container prior to binding, which is the main benefit of `mount`
- `volume`'s syntax is more straightforward

I also took the liberty of removing the `-i` flag since we don't need interactivity during tests, and when run by a non-interactive terminal (like inside an IDE), it throws `The input device is not a TTY`.