### PR TITLE
Don't force exit on makeConfig errors

### DIFF
--- a/core/util/makeConfig.js
+++ b/core/util/makeConfig.js
@@ -43,15 +43,10 @@ function loadProjectConfig (command, options, config) {
       }
       userConfig = options.config;
     } else if (config.backstopConfigFileName) {
-      try {
-        // Remove from cache config content
-        +delete require.cache[require.resolve(config.backstopConfigFileName)];
-        console.log('Loading config: ', config.backstopConfigFileName, '\n');
-        userConfig = require(config.backstopConfigFileName);
-      } catch (e) {
-        console.error('Error ' + e);
-        process.exit(1);
-      }
+      // Remove from cache config content
+      delete require.cache[require.resolve(config.backstopConfigFileName)];
+      console.log('Loading config: ', config.backstopConfigFileName, '\n');
+      userConfig = require(config.backstopConfigFileName);
     }
   }
 


### PR DESCRIPTION
Instead, allow error to bubble up. End result is the same when running via CLI, but when running in another process you don't want to force exit.