### PR TITLE
Bump dependencies: prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9208,9 +9208,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
+      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
       "dev": true
     },
     "prettier-eslint": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint-staged": "^4.3.0",
     "mocha": "^5.2.0",
     "mockery": "^1.4.0",
-    "prettier": "^1.7.4",
+    "prettier": "^1.14.3",
     "prettier-eslint-cli": "^4.7.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",


### PR DESCRIPTION
This is the last minor bump from `devDependencies`.

Next bump in the list: `eslint` 🔥 