### PR TITLE
Added a json report type

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,11 @@ Using the `report` property in your config to enable or disable browser includin
 "report": ["browser", "CI"]
 ```
 
+You can also specify a json report by specifying:
+```json
+"report": ["json"]
+```
+
 If you choose the CI-only reporting or even no reporting (CLI is always on) you can always enter the following command to see the latest test run report in the browser.
 
 ```sh
@@ -532,6 +537,7 @@ By default, BackstopJS saves generated resources into the `backstop_data` direct
     "bitmaps_test": "backstop_data/bitmaps_test",
     "engine_scripts": "backstop_data/engine_scripts",
     "html_report": "backstop_data/html_report",
+    "json_report": "backstop_data/json_report",
     "ci_report": "backstop_data/ci_report"
   }
   ...

--- a/core/util/Reporter.js
+++ b/core/util/Reporter.js
@@ -43,4 +43,11 @@ Reporter.prototype.failed = function () {
   return count;
 };
 
+Reporter.prototype.getReport = function () {
+  return {
+    testSuite: this.testSuite,
+    tests: this.tests
+  };
+};
+
 module.exports = Reporter;

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -9,6 +9,7 @@ function extendConfig (config, userConfig) {
   bitmapPaths(config, userConfig);
   ci(config, userConfig);
   htmlReport(config, userConfig);
+  jsonReport(config, userConfig);
   comparePaths(config);
   captureConfigPaths(config);
   casper(config, userConfig);
@@ -64,6 +65,15 @@ function htmlReport (config, userConfig) {
 
   config.compareConfigFileName = path.join(config.html_report, 'config.js');
   config.compareReportURL = path.join(config.html_report, 'index.html');
+}
+
+function jsonReport (config, userConfig) {
+  config.json_report = path.join(config.projectPath, 'backstop_data', 'json_report');
+  if (userConfig.paths) {
+    config.json_report = userConfig.paths.json_report || config.json_report;
+  }
+
+  config.compareJsonFileName = path.join(config.json_report, 'jsonReport.json');
 }
 
 function comparePaths (config) {

--- a/core/util/fs.js
+++ b/core/util/fs.js
@@ -8,6 +8,7 @@ var fsPromisified = {
   existsSync: fs.existsSync,
   readFile: promisify(fs.readFile),
   writeFile: promisify(fs.writeFile),
+  ensureDir: promisify(fsExtra.ensureDir),
   unlink: promisify(fs.unlink),
   remove: promisify(fsExtra.remove),
   stat: promisify(fs.stat),

--- a/test/configs/backstop_features.js
+++ b/test/configs/backstop_features.js
@@ -249,7 +249,7 @@ module.exports = {
     html_report: 'backstop_data/html_report',
     ci_report: 'backstop_data/ci_report'
   },
-  report: ['browser'],
+  report: ['browser', 'json'],
   engine: ENGINE,
   engineOptions: {
     args: ['--no-sandbox']

--- a/test/core/command/report_spec.js
+++ b/test/core/command/report_spec.js
@@ -1,0 +1,42 @@
+var mockery = require('mockery');
+var assert = require('assert');
+var sinon = require('sinon');
+
+describe('core report', function () {
+  const config = {
+    report: ['json'],
+    json_report: '/test',
+    compareJsonFileName: '/compareJson',
+    compareConfigFileName: '/compareConfig',
+    html_report: '/html_report'
+  };
+
+  before(function () {
+    mockery.enable({ warnOnUnregistered: false });
+  });
+
+  after(function () {
+    mockery.disable();
+  });
+
+  it('generates a json report and a default browser report when config.report specifies json', function () {
+    const reporterClass = { failed: () => undefined, passed: () => 'passed', getReport: () => { return { test: 123 }; } };
+    const compareMock = sinon.stub().returns(Promise.resolve(reporterClass));
+    const loggerMock = () => {
+      return { log: sinon.stub(), error: sinon.stub() };
+    };
+    const writeFileStub = sinon.stub().returns(Promise.resolve());
+    const fsMock = { ensureDir: () => Promise.resolve(), writeFile: writeFileStub, copy: () => Promise.resolve() };
+    mockery.registerMock('../util/compare/', compareMock);
+    mockery.registerMock('../util/logger', loggerMock);
+    mockery.registerMock('../util/fs', fsMock);
+
+    var report = require('../../../core/command/report');
+
+    return report.execute(config).then(() => {
+      assert.strictEqual(writeFileStub.callCount, 2);
+      assert.strictEqual(writeFileStub.calledWith('/compareJson'), true);
+      assert.strictEqual(writeFileStub.calledWith('/compareConfig'), true);
+    });
+  });
+});

--- a/test/core/util/makeConfig_it_spec.js
+++ b/test/core/util/makeConfig_it_spec.js
@@ -44,7 +44,7 @@ const expectedConfig = {
 };
 
 describe('make config', function () {
-  it('should return the default config correctly', function () {
+  it.only('should return the default config correctly', function () {
     const actualConfig = makeConfig('test');
 
     assert(actualConfig.tempCompareConfigFileName);
@@ -58,6 +58,12 @@ describe('make config', function () {
 
     assert(actualConfig.captureConfigFileName);
     delete actualConfig.captureConfigFileName;
+
+    assert(actualConfig.json_report);
+    delete actualConfig.json_report;
+
+    assert(actualConfig.compareJsonFileName);
+    delete actualConfig.compareJsonFileName;
 
     assert.deepStrictEqual(actualConfig, expectedConfig);
   });

--- a/test/core/util/makeConfig_it_spec.js
+++ b/test/core/util/makeConfig_it_spec.js
@@ -44,7 +44,7 @@ const expectedConfig = {
 };
 
 describe('make config', function () {
-  it.only('should return the default config correctly', function () {
+  it('should return the default config correctly', function () {
     const actualConfig = makeConfig('test');
 
     assert(actualConfig.tempCompareConfigFileName);


### PR DESCRIPTION
- Added the ability to create a Json report type. 

My team use the `html_report.config.js` to extract the failed tests and rerun the test suite passing in the failed test labels as `filter` values. eg `backstop test --config=<config> '--filter=<labels>`

This eliminates flakey tests which happen in our CI platform for resource issues. 

Creating a JSON report would mean we wouldn't have to remove the `report()` text in the `html_report.config.js` making the retry code much cleaner.

Also providing a JSON file means we're not likely to encounter breaking changes, as evaluating text output in the `html_report.config.js` is not very reliable.
