### PR TITLE
Puppeteer fix for creating blank (off page) screenshots

### DIFF
--- a/capture/config.default.json
+++ b/capture/config.default.json
@@ -50,5 +50,6 @@
   "asyncCaptureLimit": 5,
   "asyncCompareLimit": 50,
   "debug": false,
-  "debugWindow": false
+  "debugWindow": false,
+  "puppeteerOffscreenCaptureFix": false
 }

--- a/capture/config.default.json
+++ b/capture/config.default.json
@@ -50,6 +50,5 @@
   "asyncCaptureLimit": 5,
   "asyncCompareLimit": 50,
   "debug": false,
-  "debugWindow": false,
-  "puppeteerOffscreenCaptureFix": false
+  "debugWindow": false
 }

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -362,9 +362,9 @@ async function captureScreenshot (page, browser, selector, selectorMap, config, 
       if (el) {
         const box = await el.boundingBox();
         if (box) {
-          await el.screenshot({
-            path: path
-          });
+          var type = config.puppeteerOffscreenCaptureFix ? page : el;
+          var params = config.puppeteerOffscreenCaptureFix ? { path: path, clip: box } : { path: path };
+          await type.screenshot(params);
         } else {
           console.log(chalk.yellow(`Element not visible for capturing: ${s}`));
           return fs.copy(config.env.backstop + HIDDEN_SELECTOR_PATH, path);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"


### PR DESCRIPTION
Following to the conversation from this pull request https://github.com/garris/BackstopJS/pull/808/files, I've added the `puppeteerOffscreenCaptureFix` feature flag.

Could you please consider merging this as soon as you can? Thanks for this.