### PR TITLE
Support arguments for 'docker run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ For more info, see the [Chromy script documentation](https://github.com/OnetapIn
 ### Using Docker for testing across different environments
 We've found that different environments can render the same webpage in slightly different ways -- in particular with text. E.G. see the text in this example rendering slightly differently between Linux and Mac...
 
-![BakcstopJS OS rendering differences](http://garris.github.io/BackstopJS/assets/osRenderDifference.png)
+![BackstopJS OS rendering differences](http://garris.github.io/BackstopJS/assets/osRenderDifference.png)
 
 You can make this issue go away by rendering in a BackstopJS Docker container.  Lucky for you we've made it incredibly easy to do.  
 
@@ -670,6 +670,20 @@ then you need to add this to the root of your config...
 "url": "https://host.docker.internal/?someCoolAppParameter=true"
 ```
 
+
+#### Advanced options
+
+By default BackstopJS uses the docker image `backstopjs/backstopjs:<version>`. If you need another docker image for any reason, you can use the `dockerImage` configuration option:
+
+```json
+"dockerImage": "you/your-docker-image"
+```
+
+If you need to pass any extra arguments to the `docker run` command, use the `dockerRunExtraArgs` option:
+
+```json
+"dockerRunExtraArgs": "--shm-size=2gb"
+```
 
 ### Integration options (local install)
 

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -22,6 +22,8 @@ function extendConfig (config, userConfig) {
   config.resembleOutputOptions = userConfig.resembleOutputOptions;
   config.asyncCompareLimit = userConfig.asyncCompareLimit;
   config.backstopVersion = version;
+  config.dockerImage = userConfig.dockerImage || `backstopjs/backstopjs:${version}`;
+  config.dockerRunExtraArgs = userConfig.dockerRunExtraArgs || null;
   return config;
 }
 

--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -1,5 +1,4 @@
 const { spawn } = require('child_process');
-const version = require('../../package').version;
 
 module.exports.shouldRunDocker = (config) => config.args.docker;
 
@@ -23,7 +22,8 @@ module.exports.runDocker = (config, backstopCommand) => {
       configArgs = configArgs.replace(/--docker/, '--moby');
     }
 
-    const DOCKER_COMMAND = `docker run --rm -it --mount type=bind,source="${process.cwd()}",target=/src backstopjs/backstopjs:${version} ${backstopCommand}${configArgs} "${passAlongArgs}"`;
+    const dockerArgs = config.dockerRunExtraArgs ? ` ${config.dockerRunExtraArgs}` : '';
+    const DOCKER_COMMAND = `docker run --rm -it --mount type=bind,source="${process.cwd()}",target=/src${dockerArgs} ${config.dockerImage} ${backstopCommand}${configArgs} "${passAlongArgs}"`;
     console.log('Delegating command to Docker...', DOCKER_COMMAND);
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
I've added support for passing arguments to 'docker run' so that it is possible to use a custom image if e.g. someone needs a specific browser version.

