### PR TITLE
WIP: load local storage data

### DIFF
--- a/capture/config.default.json
+++ b/capture/config.default.json
@@ -14,12 +14,14 @@
   ],
   "onBeforeScript": "puppet/onBefore.js",
   "onReadyScript": "puppet/onReady.js",
+  "localStorageData": "Does not have precedence over the values in scenarios"
   "scenarios": [
     {
       "label": "BackstopJS Homepage",
       "cookiePath": "backstop_data/engine_scripts/cookies.json",
       "url": "https://garris.github.io/BackstopJS/",
       "referenceUrl": "",
+      "localStorageData": "backstop_data/engine_scripts/localStorage.json"
       "readyEvent": "",
       "readySelector": "",
       "delay": 0,

--- a/capture/engine_scripts/localStorage.json
+++ b/capture/engine_scripts/localStorage.json
@@ -1,0 +1,7 @@
+{
+	"amplitude_lastEventId": "2",
+	"amplitude_lastEventTime": "1543336128855",
+	"amplitude_sessionId": "1543336128827",
+	"amplitude_unsent": "[]",
+	"this_is_just_some_random_data_i_had_at_the_time_of_writing_this": "this is a string"
+}

--- a/capture/engine_scripts/puppet/loadLocalStorage.js
+++ b/capture/engine_scripts/puppet/loadLocalStorage.js
@@ -1,0 +1,40 @@
+var fs = require('fs');
+  
+/*
+  This code is called after the command to navigate has been fired. 
+  before the delay, before the wait for an element to render (readySelector) and before the code that runs just before taking the picture (readyEvent).
+
+  If the data is like this:
+  +------------------------+--------------+
+  |         Key:           |     value:   |
+  +------------------------+--------------+
+  |amplitude_lastEventId   |             2|
+  |amplitude_lastEventTime | 1543336128855|
+  |amplitude_sessionId     | 1543336128827|
+  |amplitude_unsent        |            []|
+  +------------------------+--------------+
+
+  The json should be like this:
+  {
+    "amplitude_lastEventId": "2",
+    "amplitude_lastEventTime": "1543336128855",
+    "amplitude_sessionId": "1543336128827",
+    "amplitude_unsent": "[]"
+  }
+*/
+
+async function loadLocalStorageData(path, page){
+  const localStorageData = JSON.parse(fs.readFileSync(path))
+  await page.evaluate(json => {
+    for (let key in json){
+      localStorage.setItem(key, json[key]);
+    }
+  }, localStorageData);
+}
+
+module.exports = async (page, scenario, localStorageDataPath) => {
+  localStorage.clear();
+  await loadLocalStorageData(localStorageDataPath, page);
+  // TODO: decide to only show this when debugging. And how to figure out if debug is on.
+  console.log("Local storage state restored with: ", JSON.stringify(localStorage, null, 2)); 
+};

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -118,6 +118,19 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     }
     await page.goto(translateUrl(url));
 
+		//  --- LOCAL STORAGE SCRIPT ---
+    if (scenario.localStorageData || config.localStorageData) {
+      var localStorageData = scenario.localStorageData || config.localStorageData
+      var localStorageScript = path.resolve(engineScriptsPath, 'puppet/loadLocalStorage.js');
+      
+      if (fs.existsSync(localStorageScript)) {
+        await require(localStorageScript)(page, scenario, localStorageData);
+        await page.reload();
+      } else {
+        console.warn('WARNING: script not found: ' + localStorageScript);
+      }
+    }
+    
     await injectBackstopTools(page);
 
     //  --- WAIT FOR READY EVENT ---


### PR DESCRIPTION
```It provides a place for code to be ran after the first page.goto
local storage data can now be set before the delay and the wait for readySelector.
This commit is mainly so I can get feedback.```

localStorage is only accessible after navigating to the page first.
After setting the authentication data in localStorage using the onReady script (And using page.waitfor) I was able to successfully capture the page I wanted to capture.

The delay and readySelector property is rendered useless if your application needs to use of localStorage. 

It seems clunky so here is my pull request.

What do you think?
I have yet to run this code at this point in time.