### PR TITLE
Adding support for a gotoOptions config option

### DIFF
--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -192,7 +192,12 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
   if (isReference && scenario.referenceUrl) {
     url = scenario.referenceUrl;
   }
-  chromy.goto(url);
+  var gotoOptions = scenario.gotoOptions || config.gotoOptions;
+  if (gotoOptions) {
+    chromy.goto(url, gotoOptions);
+  } else {
+    chromy.goto(url);
+  }
 
   injectBackstopTools(chromy);
 


### PR DESCRIPTION
Adding support for a gotoOptions config option, to be passed to Chromy, primarily for setting waitLoadEvent:false