### PR TITLE
Fixes #932: Adds CJK language support.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,18 @@ RUN	apt-get -y update && \
 
 RUN apt-get install -y firefox-esr
 
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
+    libfontconfig \
+    libfreetype6 \
+    xfonts-cyrillic \
+    xfonts-scalable \
+    fonts-liberation \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -qyy clean
+
 WORKDIR /src
 
 ENTRYPOINT ["backstop"]


### PR DESCRIPTION
# Changes

- Fixes https://github.com/garris/BackstopJS/issues/932.
- Installs additional font libraries for wide-ranging multilingual support.

Example:
<img width="1421" alt="backstopjs_report" src="https://user-images.githubusercontent.com/419534/52101893-a33f9800-25ab-11e9-9e82-882d398a8f3e.png">
