### PR TITLE
openReport config checked when running 'test' via docker

### DIFF
--- a/core/command/test.js
+++ b/core/command/test.js
@@ -8,11 +8,11 @@ module.exports = {
     const executeCommand = require('./index');
     if (shouldRunDocker(config)) {
       return runDocker(config, 'test')
-          .finally(() => {
-              if (config.openReport && config.report && config.report.indexOf('browser') > -1) {
-                  executeCommand('_openReport', config);
-              }
-          });
+        .finally(() => {
+          if (config.openReport && config.report && config.report.indexOf('browser') > -1) {
+            executeCommand('_openReport', config);
+          }
+        });
     } else {
       return createBitmaps(config, false).then(function () {
         return executeCommand('_report', config);

--- a/core/command/test.js
+++ b/core/command/test.js
@@ -8,7 +8,11 @@ module.exports = {
     const executeCommand = require('./index');
     if (shouldRunDocker(config)) {
       return runDocker(config, 'test')
-        .finally(() => executeCommand('_openReport', config));
+          .finally(() => {
+              if (config.openReport && config.report && config.report.indexOf('browser') > -1) {
+                  executeCommand('_openReport', config);
+              }
+          });
     } else {
       return createBitmaps(config, false).then(function () {
         return executeCommand('_report', config);


### PR DESCRIPTION
This simple logic change alters the docker branch of `backstop test` so it performs the same config check that `report.js` performs before calling `_openReport`.

As-is, when run via docker, the report is _always_ opened, no matter how the config is set.