### PR TITLE
Include emoji font in docker image 🤓

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,12 @@ RUN apt-get -qqy update \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get -qyy clean
 
+# install emoji font from debian testing distribution
+RUN apt-add-repository "deb http://deb.debian.org/debian testing main" \
+ && apt-get update -qq \
+ && apt-get install -yqq --no-install-recommends fonts-noto-color-emoji \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /src
 
 ENTRYPOINT ["backstop"]


### PR DESCRIPTION
The official backstopjs docker image does not include any emoji font, so emoji chars show as square boxes in the screenshots.

This change to the Dockerfile installs the "Noto" font, also used by Android for emoji.