### PR TITLE
Notification board in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 BackstopJS automates visual regression testing of your responsive web UI by comparing DOM screenshots over time.
 
+## !! Notification board !!
+Due to some recent updates to the repo the latest version will produce the following error: ```Error: Failed to launch chrome!``` If you want to avoid that please use a previous stable version instead, such as v3.9.5. If you are using docker please use the (crtl/cmd + F) "dockerCommandTemplate" and specify a version.
+
 ## Version 3 Features
 
 - In-browser reporting UI with...


### PR DESCRIPTION
I am adding a notification board section near the top of the readme file to inform users of the repo what is currently going on with the latest build. I was quite confused myself when I ran backstop this morning to find out that Chrome was not running anymore. I had to go through closed pull requests and commits to find out what caused the issue, which is a bit tedious. I think this space could be useful.
P.S. I put in the last version of backstop that worked for me but if there is a later stable version please update @garris