### PR TITLE
style: fix lint error by removing trailing comma

### DIFF
--- a/test/configs/backstop_features.js
+++ b/test/configs/backstop_features.js
@@ -21,7 +21,7 @@ module.exports = {
   scenarios: [
     {
       label: 'Simple',
-      url: `${URL}`,
+      url: `${URL}`
     },
     {
       label: 'pkra bug test',


### PR DESCRIPTION
This will fix the [failing build](https://travis-ci.org/garris/BackstopJS/builds/512785903?utm_source=github_status&utm_medium=notification) from the latest 4.0.3 release; hope this helps!