### PR TITLE
Fix removeSelectors bug

### DIFF
--- a/core/util/runChromy.js
+++ b/core/util/runChromy.js
@@ -230,7 +230,7 @@ function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabe
         .evaluate(
           () => {
             Array.prototype.forEach.call(document.querySelectorAll(window._backstopSelector), function (s, j) {
-              s.style.display = 'none';
+              s.style.cssText = 'display: none !important;';
               s.classList.add('__86d');
             });
           }

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -148,7 +148,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
             await page
               .evaluate((sel) => {
                 document.querySelectorAll(sel).forEach(s => {
-                  s.style.display = 'none';
+                  s.style.cssText = 'display: none !important;';
                   s.classList.add('__86d');
                 });
               }, selector);


### PR DESCRIPTION
I added !important to display none to remove elements really. It is necessary because the selected elements can have styles with important too, for example in Bootstrap the d-* helpers:

`<div class="d-flex">I want to be a flex element</div>`

```
.d-flex {
    display: -webkit-box!important;
    display: -webkit-flex!important;
    display: -moz-box!important;
    display: -ms-flexbox!important;
    display: flex!important;
}
```