### PR TITLE
Add approve to list of scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "init": "node ./cli/index.js init",
     "reference": "node ./cli/index.js reference",
     "test": "node ./cli/index.js test",
+    "approve": "node ./cli/index.js approve",
     "openReport": "node ./cli/index.js openReport",
     "echo": "node ./cli/index.js echo",
     "unit-test": "mocha --reporter spec --recursive 'test/**/*_spec.js'",


### PR DESCRIPTION
While working on https://github.com/garris/BackstopJS/pull/1079 I noticed that `approve` is the only backstop command that is not exposed in "scripts".

I thought that maybe it's an oversight, so I'm adding it