### PR TITLE
(Proposal) baseUrl config property

### DIFF
--- a/core/util/createBitmaps.js
+++ b/core/util/createBitmaps.js
@@ -3,6 +3,7 @@ var cloneDeep = require('lodash/cloneDeep');
 var fs = require('./fs');
 var each = require('./each');
 var pMap = require('p-map');
+const path = require('path');
 
 var runChromy = require('./runChromy');
 var runPuppet = require('./runPuppet');
@@ -100,6 +101,11 @@ function delegateScenarios (config) {
     scenario.sIndex = i;
     scenario.selectors = scenario.selectors || [];
     scenario.viewports && scenario.viewports.forEach(saveViewportIndexes);
+    
+    if (config.baseUrl && config.baseUrl.trim()) {
+      scenario.url = path.join(config.baseUrl, scenario.url);  
+    }
+
     scenarios.push(scenario);
 
     if (!config.isReference && scenario.hasOwnProperty('variants')) {


### PR DESCRIPTION
I used BackstopJS on a project that required hundreds of scenarios, and I found it kinda awkward having to redeclare the base url for every single scenario, even though of course it was always the same

In the end we were using a gulp wrapper to, among other things, get rid of this duplication, but I thought it would be pretty useful to provide out-of-the-box the ability to declare the base url once and then forget about it

So instead of doing this

```json
{
  "scenarios": [
    {
      "label": "Homepage",
      "url": "https://mysite.com/"
    },
    {
      "label": "Start",
      "url": "https://mysite.com/start"
    },
    {
      "label": "Support",
      "url": "https://mysite.com/support"
    },
    {
      "label": "Contact",
      "url": "https://mysite.com/contact"
    }
  ]
}
```
one could do this
```json
{
  "baseUrl": "https://mysite.com/",
  "scenarios": [
    {
      "label": "Homepage",
      "url": "/"
    },
    {
      "label": "Start",
      "url": "/start"
    },
    {
      "label": "Support",
      "url": "/support"
    },
    {
      "label": "Contact",
      "url": "/contact"
    }
  ]
}
```
The property could be optional and inconsistencies with leading/trailing slashes would be taken care of on runtime (by using the `path` module)

I included a very quick proof of concept where I tried to find the most upstream place where `scenario.url` gets defined, so it can be amended before being used by other scripts

@garris let me know what you think, if you are interested then I could add tests (although you would have to tell me where, I'm not sure I found the correct place where to put them), add some documentation, etc

Thanks!