### PR TITLE
Added option to override the report base path for resources

### DIFF
--- a/core/command/report.js
+++ b/core/command/report.js
@@ -45,11 +45,26 @@ function writeBrowserReport (config, reporter) {
     for (var i in browserReporter.tests) {
       if (browserReporter.tests.hasOwnProperty(i)) {
         var pair = browserReporter.tests[i].pair;
-        pair.reference = path.relative(report, toAbsolute(pair.reference));
-        pair.test = path.relative(report, toAbsolute(pair.test));
+        var pathReference = path.relative(report, toAbsolute(pair.reference));
+        var pathTest = path.relative(report, toAbsolute(pair.test));
+
+        if (config.report_resource_base_url) {
+          pathReference = toAbsolute(config.report_resource_base_url + pair.reference);
+          pathTest = toAbsolute(config.report_resource_base_url + pair.test);
+        }
+
+        pair.reference = pathReference;
+        pair.test = pathTest;
 
         if (pair.diffImage) {
-          pair.diffImage = path.relative(report, toAbsolute(pair.diffImage));
+          var pathDiff = path.relative(report, toAbsolute(pair.diffImage));
+          if (config.report_resource_base_url) {
+            var backstopDataPosition = pair.diffImage.indexOf('backstop_data');
+            var relativePart = pair.diffImage.substr(backstopDataPosition);
+            pathDiff = toAbsolute(config.report_resource_base_url + relativePart);
+          }
+
+          pair.diffImage = pathDiff;
         }
       }
     }

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -61,6 +61,10 @@ function htmlReport (config, userConfig) {
 
   if (userConfig.paths) {
     config.html_report = userConfig.paths.html_report || config.html_report;
+
+    if (userConfig.paths.report_resource_base_url) {
+      config.report_resource_base_url = userConfig.paths.report_resource_base_url;
+    }
   }
 
   config.compareConfigFileName = path.join(config.html_report, 'config.js');


### PR DESCRIPTION
For our CI Integration, we need to specify the baseUrl where the Report loads resources from.
It may be an edge case but it's really necessary for us.

I opened an Issue aswell:
https://github.com/garris/BackstopJS/issues/1093