### PR TITLE
Resolve promises for docker arguments

### DIFF
--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -23,7 +23,7 @@ module.exports.runDocker = async (config, backstopCommand) => {
     // When calling BackstopJS from node config props will be overridden by the passed config object. e.g. backstop('test', {thisProp:'will be passed to config.args'})
     let configArgs = '';
     if (config.args && !config.args._) {
-      configArgs = Object.keys(config.args)
+      const argPromises = Object.keys(config.args)
         .map(async prop => {
           if (prop === 'config' && typeof config.args[prop] === 'object') {
             // If config is an object, export it to a json file
@@ -32,9 +32,11 @@ module.exports.runDocker = async (config, backstopCommand) => {
           }
 
           return `"--${prop}=${config.args[prop]}"`;
-        })
-        .join(' ')
-        .replace(/--docker/, '--moby');
+        });
+
+      configArgs = await Promise.all(argPromises).then((str) => {
+        return str.join(' ').replace(/--docker/, '--moby');
+      });
     }
 
     const backstopArgs = [configArgs, passAlongArgs]


### PR DESCRIPTION
This is a fix to an issue introduced by #988 

Reproduction of issue:
```
const backstop = require('backstopjs');
/* ... */
backstop('test', { docker: true, config: 'some/path' })
/* ... */
```
Running with docker and any configuration will fail due to the current code attempting to join promises. Simplified error message that is produced (note `[object Promise]` in the end):
```
Error: docker run --rm -it --mount type=bind,source="some/path",target=/src backstopjs/backstopjs:4.3.2 test [object Promise] [object Promise] returned 1
```