### PR TITLE
Copy viewport objects

### DIFF
--- a/core/util/createBitmaps.js
+++ b/core/util/createBitmaps.js
@@ -82,7 +82,7 @@ function decorateConfigForCapture (config, isReference) {
 }
 
 function saveViewportIndexes (viewport, index) {
-  return Object.assign({}, viewport, {vIndex: index});
+  return Object.assign({}, viewport, { vIndex: index });
 }
 
 function delegateScenarios (config) {

--- a/core/util/createBitmaps.js
+++ b/core/util/createBitmaps.js
@@ -82,7 +82,7 @@ function decorateConfigForCapture (config, isReference) {
 }
 
 function saveViewportIndexes (viewport, index) {
-  viewport.vIndex = index;
+  return Object.assign({}, viewport, {vIndex: index});
 }
 
 function delegateScenarios (config) {
@@ -92,14 +92,16 @@ function delegateScenarios (config) {
   var scenarios = [];
   var scenarioViews = [];
 
-  config.viewports.forEach(saveViewportIndexes);
+  config.viewports = config.viewports.map(saveViewportIndexes);
 
   // casper.each(scenarios, function (casper, scenario, i) {
   config.scenarios.forEach(function (scenario, i) {
     // var scenarioLabelSafe = makeSafe(scenario.label);
     scenario.sIndex = i;
     scenario.selectors = scenario.selectors || [];
-    scenario.viewports && scenario.viewports.forEach(saveViewportIndexes);
+    if (scenario.viewports) {
+      scenario.viewports = scenario.viewports.map(saveViewportIndexes);
+    }
     scenarios.push(scenario);
 
     if (!config.isReference && scenario.hasOwnProperty('variants')) {


### PR DESCRIPTION
Consider the following configuration:
```javascript
const defaultViewports = [
  {
    label: 'sm',
    ...
  },
  {
    label: 'md',
    ...
  },
  {
    label: 'xl',
    ...
  },
];

const backstopConfig = {
   viewports: defaultViewports,
   scenarios: [
     {
        label: 'scenario A',
        ...
     },
     {
        label: 'scenario B (only runs on xl viewport)',
        viewports: defaultViewports.filter(viewport => viewport.label === 'xl'),
        ...
     },
     {
        label: 'scenario C',
        ...
     },
   ],
   ...
};
```
Given that the viewport index is saved in the viewport object itself, in the previous example, both 'sm' and 'xl' will always have the index 0, because the `scenario B` viewports config will override the global 'xl' index.

With this PR, it's created a copy of each viewport configuration, making possible to reuse viewports configuration with predictable viewports indexes.