### PR TITLE
fix #1113 `filter: undefined` option is passed as `--filter=undefined` when run with Docker

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -6,7 +6,7 @@ var version = require('../package.json').version;
 var runner = require('../core/runner');
 
 var argsOptions = parseArgs(process.argv.slice(2), {
-  boolean: ['h', 'help', 'v', 'version', 'i'],
+  boolean: ['h', 'help', 'v', 'version', 'i', 'docker'],
   string: ['config'],
   default: {
     config: 'backstop.json'

--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -24,6 +24,7 @@ module.exports.runDocker = async (config, backstopCommand) => {
     let configArgs = '';
     if (config.args && !config.args._) {
       const argPromises = Object.keys(config.args)
+        .filter(prop => config.args[prop])
         .map(async prop => {
           if (prop === 'config' && typeof config.args[prop] === 'object') {
             // If config is an object, export it to a json file

--- a/test/configs/backstop_alt.js
+++ b/test/configs/backstop_alt.js
@@ -1,5 +1,5 @@
 module.exports = {
-  id: `backstop_alt`,
+  id: `puppet_backstop_features`,
   viewports: [
     {
       label: 'phone',

--- a/test/configs/runFromNode.js
+++ b/test/configs/runFromNode.js
@@ -1,11 +1,12 @@
 // Go get a hook to BackstopJS
-const backstop = require('../../../backstopjs');
+const backstop = require('../../core/runner');
 
 // Run BackstopJS with docker
-// NOTE: passing config file name is supported -- passing actual config data is not supported.
+// NOTE: passing either config file name or actual config object is supported.
 backstop('test', {
   docker: true,
-  config: 'backstop_alt'
+  config: 'backstop_alt',
+  filter: undefined
 }).then(
   () => console.log('nothing new'),
   () => console.log('changes found')

--- a/test/core/util/runDocker_spec.js
+++ b/test/core/util/runDocker_spec.js
@@ -19,8 +19,8 @@ describe('runDocker', function () {
       spawn: function (dockerCommand) {
         assert.strictEqual(
           dockerCommand,
-          'docker run --rm -it --mount type=bind,source="/path/mock",target=/src backstopjs/backstopjs:version.mock test'
-            + ' "--moby=true" "--config=my_config.json" "--filter=my_filter"');
+          'docker run --rm -it --mount type=bind,source="/path/mock",target=/src backstopjs/backstopjs:version.mock test' +
+          ' "--moby=true" "--config=my_config.json" "--filter=my_filter"');
         done();
         return { on: () => {} };
       }
@@ -62,7 +62,7 @@ describe('runDocker', function () {
   it('should create tmp config file if config arg is an object', function (done) {
     process.argv = ['test'];
     mockery.registerMock('./fs', {
-      writeFile: function() {
+      writeFile: function () {
         return Promise.resolve();
       }
     });

--- a/test/core/util/runDocker_spec.js
+++ b/test/core/util/runDocker_spec.js
@@ -1,0 +1,89 @@
+const mockery = require('mockery');
+const assert = require('assert');
+
+describe('runDocker', function () {
+  beforeEach(function () {
+    mockery.enable({ warnOnUnregistered: false, useCleanCache: true });
+  });
+
+  afterEach(function () {
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  it('should run correct docker command', function (done) {
+    process.cwd = () => '/path/mock';
+    process.argv = ['test'];
+    mockery.registerMock('../../package', { version: 'version.mock' });
+    mockery.registerMock('child_process', {
+      spawn: function (dockerCommand) {
+        assert.strictEqual(
+          dockerCommand,
+          'docker run --rm -it --mount type=bind,source="/path/mock",target=/src backstopjs/backstopjs:version.mock test'
+            + ' "--moby=true" "--config=my_config.json" "--filter=my_filter"');
+        done();
+        return { on: () => {} };
+      }
+    });
+
+    const config = {
+      args: {
+        docker: true,
+        config: 'my_config.json',
+        filter: 'my_filter'
+      }
+    };
+
+    const { runDocker } = require('../../../core/util/runDocker');
+    runDocker(config, 'test');
+  });
+
+  it('should not pass undefined args to docker', function (done) {
+    process.argv = ['test'];
+    mockery.registerMock('child_process', {
+      spawn: function (dockerCommand) {
+        assert(!dockerCommand.includes('--filter'));
+        done();
+        return { on: () => {} };
+      }
+    });
+
+    const config = {
+      args: {
+        docker: true,
+        filter: undefined
+      }
+    };
+
+    const { runDocker } = require('../../../core/util/runDocker');
+    runDocker(config, 'test');
+  });
+
+  it('should create tmp config file if config arg is an object', function (done) {
+    process.argv = ['test'];
+    mockery.registerMock('./fs', {
+      writeFile: function() {
+        return Promise.resolve();
+      }
+    });
+    mockery.registerMock('child_process', {
+      spawn: function (dockerCommand) {
+        assert(dockerCommand.includes('--config=backstop.config-for-docker.json'));
+        done();
+        return { on: () => {} };
+      }
+    });
+
+    const config = {
+      args: {
+        docker: true,
+        config: {
+          id: 'i_am_a_config_object'
+        }
+      }
+    };
+
+    const { runDocker } = require('../../../core/util/runDocker');
+    runDocker(config, 'test');
+  });
+});


### PR DESCRIPTION
Hello, here is the fix for #1113 :smiley: 

The fix itself is one line in `core/util/runDocker.js`.

I also added some tests and fixed some related code.