### PR TITLE
remove  type="text/javascript" from reports

### DIFF
--- a/compare/output/index.html
+++ b/compare/output/index.html
@@ -33,12 +33,12 @@
     <div id="root">
 
     </div>
-    <script type="text/javascript">
+    <script>
       function report (report) { // eslint-disable-line no-unused-vars
         window.tests = report;
       }
     </script>
-    <script type="text/javascript" src="config.js"></script>
-    <script type="text/javascript" src="index_bundle.js"></script>
+    <script src="config.js"></script>
+    <script src="index_bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
not needed for HTML5 documents