### PR TITLE
Fix ugly bug with setViewport function

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -65,7 +65,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
   const browser = await puppeteer.launch(puppeteerArgs);
   const page = await browser.newPage();
 
-  page.setViewport({ width: VP_W, height: VP_H });
+  await page.setViewport({ width: VP_W, height: VP_H });
   page.setDefaultNavigationTimeout(engineTools.getEngineOption(config, 'waitTimeout', TEST_TIMEOUT));
 
   if (isReference) {


### PR DESCRIPTION
Function 'setViewport' is async. So, we have to write await before call async function.
This bug causes errors with actions on resized pages. Espiecially on smaller screens on phone.