### PR TITLE
feat(remote): use report paths from config

### DIFF
--- a/remote/index.js
+++ b/remote/index.js
@@ -108,9 +108,7 @@ module.exports = function (app) {
       });
 
       const reportConfigFilename = path.join(
-        PROJECT_PATH,
-        'backstop_data',
-        'html_report',
+        _config.paths.html_report,
         'config.js'
       );
       await modifyJsonpReport({


### PR DESCRIPTION
Instead of using a hardcoded (default) path for the report,
use the path set in the backstop config. This allows custom paths.