### PR TITLE
Adapte scrollToSelector to xpath selector

### DIFF
--- a/capture/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/capture/engine_scripts/puppet/clickAndHoverHelper.js
@@ -31,9 +31,16 @@ module.exports = async (page, scenario) => {
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+   await page.waitFor(scrollToSelector);
+    if (scrollToSelector.startsWith('//')){
+      await page.evaluate(scrollToSelector => {
+        document.evaluate(scrollToSelector, document, null, XPathResult.ANY_TYPE, null ).iterateNext().scrollIntoView();
+      }, scrollToSelector);
+    }else{
+
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);
+  }
   }
 };


### PR DESCRIPTION
QuerySelector only works for CSS selector . As puppeteer support both CSS selector & xpath selector , add the piece of code can help scrollToSelector to use xpath selector . CSS selector does not support modern pseudo syntax which limit its use . Xpath can be used as a workaround .