### PR TITLE
Feature/reload page on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,18 @@ module.exports = async (page, scenario, vp) => {
 };
 ```
 
+### Reload scenario on specific error (puppeteer)
+
+By default puppeteer will take a screenshot even if the URL returned http status different than 200. If you want to reload website on failure (only once), add the following code to `backstop.json`.
+
+```json
+"reloadOnError": {
+  "enable": true, // Whether website should be reloaded on error
+  "waitBeforeReload": 1500, // Wait 1500ms before reload
+  "onStatus": [504, 503, 500] // Reload website if responded with one of the following statuses
+},
+```
+
 #### Setting the base path for custom onBefore and onReady scripts
 
 By default the base path is a folder called `engine_scripts` inside your BackstopJS installation directory. You can override this by setting the `paths.scripts` property in your `backstop.json` file to point to somewhere in your project directory (recommended).

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ By default puppeteer will take a screenshot even if the URL returned http status
   "onStatus": [504, 503, 500] // Reload website if responded with one of the following statuses
 },
 ```
+Keep in mind that it works fine only with puppeteer `"engine": "puppeteer"`.
 
 #### Setting the base path for custom onBefore and onReady scripts
 


### PR DESCRIPTION
In some scenarios, servers might be overloaded and return http status like 504 - in this case the screenshots will be not valid. 

This is why I've added a simple function that load URL again after some declared time.