### PR TITLE
fix(docs): onBefore / onReady arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,10 +480,10 @@ By default the base path is a folder called `engine_scripts` inside your Backsto
 
 #### onBeforeScript/onReadyScript available variables
 
-onBefore(engine, scenario, viewport, isReference, Engine, config)
+onBefore(page, scenario, viewport, isReference, Engine, config)
 
 ```
-engine:      puppeteer engine instance
+engine:      browser page object
 scenario:    currently running scenario config
 viewport:    viewport info
 isReference: whether scenario contains reference URL property


### PR DESCRIPTION
The first argument is the page object, not the engine.

https://github.com/garris/BackstopJS/blob/9e2ecf7dd5b623195b10af987555c68ef668412a/core/util/runPuppet.js#L110