### PR TITLE
fixes more issues with capturing elements out of the viewport

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -435,6 +435,13 @@ async function captureScreenshot (page, browser, selector, selectorMap, config, 
           var type = config.puppeteerOffscreenCaptureFix ? page : el;
           var params = config.puppeteerOffscreenCaptureFix ? { path: path, clip: box } : { path: path };
 
+          if(config.puppeteerOffscreenCaptureFix) {
+            const pageHeight = await page.evaluate("document.body.scrollHeight");
+            await type.setViewport(
+              Object.assign({}, type.viewport(), {height: parseInt(pageHeight) })
+            );
+          }
+
           await type.screenshot(params);
         } else {
           console.log(chalk.yellow(`Element not visible for capturing: ${s}`));


### PR DESCRIPTION
This is a fix for issue #1210. The possible drawback to this is that it expands the height of the viewport. 

It's piggy-packing on the puppeteerOffscreenCaptureFix config, which isn't necessary, but it seemed overkill to add another edge case config item that is addressing the same issue. However, if expanding the height of the viewport isn't acceptable when using puppeteerOffscreenCaptureFix, it would be helpful if we could add another config item to enable this code since I'm getting nothing but gray boxes for things outside the viewport without it.