### PR TITLE
Using interactive mode and reference mode in backstop remote

### DIFF
--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -10,15 +10,18 @@ module.exports = {
     const projectPath = path.resolve(config.projectPath);
 
     return new Promise(function (resolve, reject) {
-      logger.log(`Starting remote with: node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`);
+      let commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
+      if (config && config.args && config.args.i) {
+        commandStr = `${commandStr} --i ${config.args.i}`;
+      }
 
-      const child = exec(`node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`);
+      logger.log(`Starting remote with: ${commandStr}`);
 
-      child.stdout.on('data', (data) => {
-        logger.log(data);
-      });
+      const child = exec(commandStr);
 
-      child.stdout.on('close', (data) => {
+      child.stdout.on('data', logger.log);
+
+      child.stdout.on('close', data => {
         logger.log('Backstop remote connection closed.', data);
         resolve(data);
       });

--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -11,9 +11,6 @@ module.exports = {
 
     return new Promise(function (resolve, reject) {
       let commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
-      if (config && config.args && config.args.i) {
-        commandStr = `${commandStr} --i ${config.args.i}`;
-      }
 
       logger.log(`Starting remote with: ${commandStr}`);
 

--- a/remote/index.js
+++ b/remote/index.js
@@ -3,7 +3,8 @@
 
 var parseArgs = require('minimist');
 var argsOptions = parseArgs(process.argv.slice(2), {
-  string: ['config']
+  string: ['config'],
+  boolean: ['i']
 });
 var PROJECT_PATH = argsOptions._[0];
 var PATH_TO_CONFIG = argsOptions.config;
@@ -66,7 +67,8 @@ module.exports = function (app) {
       vid: app._backstop.testCtr
     };
 
-    backstop('test', { config }).then(
+    // TODO: how to fork test vs reference
+    backstop('reference', { config, i: argsOptions.i }).then(
       () => {
         result.ok = true;
         res.send(JSON.stringify(result));

--- a/remote/index.js
+++ b/remote/index.js
@@ -32,7 +32,7 @@ module.exports = function (app) {
     next();
   });
 
-  app.post('/dtest/:testId/:scenarioId', (req, res) => {
+  app.post(['/dtest/:testId/:scenarioId', '/dref/:testId/:scenarioId'], (req, res) => {
     app._backstop.testCtr++;
 
     if (!(req.params.testId in app._backstop.tests)) {
@@ -67,8 +67,8 @@ module.exports = function (app) {
       vid: app._backstop.testCtr
     };
 
-    // TODO: how to fork test vs reference
-    backstop('reference', { config, i: argsOptions.i }).then(
+    const command = req.path.includes('dtest') ? 'test' : 'reference';
+    backstop(command, { config, i: argsOptions.i }).then(
       () => {
         result.ok = true;
         res.send(JSON.stringify(result));

--- a/remote/index.js
+++ b/remote/index.js
@@ -3,8 +3,7 @@
 
 var parseArgs = require('minimist');
 var argsOptions = parseArgs(process.argv.slice(2), {
-  string: ['config'],
-  boolean: ['i']
+  string: ['config']
 });
 var PROJECT_PATH = argsOptions._[0];
 var PATH_TO_CONFIG = argsOptions.config;
@@ -68,7 +67,7 @@ module.exports = function (app) {
     };
 
     const command = req.path.includes('dtest') ? 'test' : 'reference';
-    backstop(command, { config, i: argsOptions.i }).then(
+    backstop(command, { config, i: Boolean(req.body.i) }).then(
       () => {
         result.ok = true;
         res.send(JSON.stringify(result));


### PR DESCRIPTION
Backstop already supports config to use interactive mode but it was not passed on to backstop remote.

**Changes include:**
- Ability to switch between reference and test modes in backstop remote
- Enable option to use interactive mode in backstop remote