### PR TITLE
Improve handling edge cases

### DIFF
--- a/remote/index.js
+++ b/remote/index.js
@@ -14,6 +14,8 @@ var express = require('express');
 var backstop = require('../core/runner');
 var { modifyJsonpReport } = require('../core/util/remote');
 
+const booleanizeArg = incrementalFlag => [true, 'true'].includes(incrementalFlag);
+
 module.exports = function (app) {
   app._backstop = app._backstop || {};
   app._backstop.testCtr = 0;
@@ -67,7 +69,7 @@ module.exports = function (app) {
     };
 
     const command = req.path.includes('dtest') ? 'test' : 'reference';
-    backstop(command, { config, i: Boolean(req.body.i) }).then(
+    backstop(command, { config, i: booleanizeArg(req.body.i) }).then(
       () => {
         result.ok = true;
         res.send(JSON.stringify(result));

--- a/remote/index.js
+++ b/remote/index.js
@@ -68,7 +68,7 @@ module.exports = function (app) {
       vid: app._backstop.testCtr
     };
 
-    const command = req.path.includes('dtest') ? 'test' : 'reference';
+    const command = req.path.includes(`/dref/`) ? 'reference' : 'test';
     backstop(command, { config, i: booleanizeArg(req.body.i) }).then(
       () => {
         result.ok = true;


### PR DESCRIPTION
This PR addresses some comments(from https://github.com/garris/BackstopJS/pull/1216) around handling some edge cases in a better way.

**Changes:**
* better handling of boolean flag - incremental flag
* stricter check for `/dtest` based on which reference or test modes are selected.

_P.S: Tested against _ember-backstop-tutorial_ repo._