### PR TITLE
add mode to webpack config

### DIFF
--- a/compare/webpack.config.js
+++ b/compare/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  mode: 'production',
   entry: './compare/src/index.js',
   output: {
     path: path.resolve(__dirname, 'output'),


### PR DESCRIPTION
This PR will add `mode: 'production'` to the webpack config.
Since it is the default nothing should break.