### PR TITLE
Fix lint command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ First off, You are awesome! Thanks for your interest, time and hard work!  Here 
 ### We use `eslint-config-semistandard`.
 Please run the linter before each submit, as follows. Thank you. 🙇🏽
 ```sh
-$ npm run lint --fix
+$ npm run lint -- --fix
 ```
 
 


### PR DESCRIPTION
In `npm run lint --fix`, the argument  `--fix` is ignored, we should add `--` before it to get it passed to the actual eslint command. See:

https://stackoverflow.com/questions/11580961/sending-command-line-arguments-to-npm-script