### PR TITLE
Remove cookie domain as it could be munged from scenario url

### DIFF
--- a/capture/engine_scripts/cookies.json
+++ b/capture/engine_scripts/cookies.json
@@ -1,6 +1,5 @@
 [
   {
-    "domain": ".www.yourdomain.com",
     "path": "/",
     "name": "yourCookieName",
     "value": "yourCookieValue",

--- a/capture/engine_scripts/puppet/loadCookies.js
+++ b/capture/engine_scripts/puppet/loadCookies.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 module.exports = async (page, scenario) => {
-  let cookies = [];
+  const cookies = [];
   const cookiePath = scenario.cookiePath;
 
   // READ COOKIES FROM FILE IF EXISTS
@@ -9,10 +9,14 @@ module.exports = async (page, scenario) => {
     cookies = JSON.parse(fs.readFileSync(cookiePath));
   }
 
-  // MUNGE COOKIE DOMAIN
+  // Inject cookie domain, url, secure from scenario url.
+  const url = new URL(scenario.url);
   cookies = cookies.map(cookie => {
-    cookie.url = 'https://' + cookie.domain;
-    delete cookie.domain;
+    cookie.url = `${url.protocol}//${url.hostname}`;
+    cookie.domain = url.hostname;
+    if(url.protocol === 'https:') {
+      cookie.secure = true;
+    }
     return cookie;
   });
 


### PR DESCRIPTION
When trying to make our our pipeline multi domain compatible we stumbled into the cookie domain setting in provided by default in cookies.json. With a little fix in loadCookies.json you can avoid specifying domain per cookie. 

I think it might be a good default setting. 