### PR TITLE
feat(loadCookies): check for http and https in cookie domain

### DIFF
--- a/capture/engine_scripts/puppet/loadCookies.js
+++ b/capture/engine_scripts/puppet/loadCookies.js
@@ -11,7 +11,11 @@ module.exports = async (page, scenario) => {
 
   // MUNGE COOKIE DOMAIN
   cookies = cookies.map(cookie => {
-    cookie.url = 'https://' + cookie.domain;
+    if (cookie.domain.startsWith('http://') || cookie.domain.startsWith('https://')) {
+      cookie.url = cookie.domain;
+    } else {
+      cookie.url = 'https://' + cookie.domain;
+    }
     delete cookie.domain;
     return cookie;
   });

--- a/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/loadCookies.js
+++ b/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/loadCookies.js
@@ -11,7 +11,11 @@ module.exports = async (page, scenario) => {
 
   // MUNGE COOKIE DOMAIN
   cookies = cookies.map(cookie => {
-    cookie.url = 'https://' + cookie.domain;
+    if (cookie.domain.startsWith('http://') || cookie.domain.startsWith('https://')) {
+      cookie.url = cookie.domain;
+    } else {
+      cookie.url = 'https://' + cookie.domain;
+    }
     delete cookie.domain;
     return cookie;
   });
@@ -23,7 +27,7 @@ module.exports = async (page, scenario) => {
         await page.setCookie(cookie);
       })
     );
-  }
+  };
   await setCookies();
   console.log('Cookie state restored with:', JSON.stringify(cookies, null, 2));
 };

--- a/examples/responsiveDemo/backstop_data/engine_scripts/puppet/loadCookies.js
+++ b/examples/responsiveDemo/backstop_data/engine_scripts/puppet/loadCookies.js
@@ -11,7 +11,11 @@ module.exports = async (page, scenario) => {
 
   // MUNGE COOKIE DOMAIN
   cookies = cookies.map(cookie => {
-    cookie.url = 'https://' + cookie.domain;
+    if (cookie.domain.startsWith('http://') || cookie.domain.startsWith('https://')) {
+      cookie.url = cookie.domain;
+    } else {
+      cookie.url = 'https://' + cookie.domain;
+    }
     delete cookie.domain;
     return cookie;
   });


### PR DESCRIPTION
By testing localhost mostly there is no https connection.
To be able to set it and prevent double http in the url a check was added.