### PR TITLE
Fix issue with mergeImgHack resulting in whitespace

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -1,4 +1,3 @@
-const MERGE_IMG_SEGMENT_HEIGHT = 2000;
 const puppeteer = require('puppeteer');
 
 const mergeImg = require('merge-img');
@@ -357,7 +356,7 @@ async function captureScreenshot (page, browser, selector, selectorMap, config, 
       // Safer version of `document` selector
       // see https://github.com/garris/BackstopJS/issues/820
       try {
-        const screenHeight = typeof config.mergeImgHack === 'number' ? config.mergeImgHack : MERGE_IMG_SEGMENT_HEIGHT;
+        const screenHeight = typeof config.mergeImgHack === 'number' ? config.mergeImgHack : viewport.height;
 
         const bodyHandle = await page.$('body');
         const { width, height: totalHeight } = await bodyHandle.boundingBox();
@@ -367,6 +366,11 @@ async function captureScreenshot (page, browser, selector, selectorMap, config, 
         for (let i = 0; i * screenHeight < totalHeight; i++) {
           cumHeight += screenHeight;
           console.log(`screenshot part ${i} (${Math.min(cumHeight, totalHeight)} / ${totalHeight})`);
+
+          await page.evaluate((i, screenHeight) => {
+            window.scrollTo(0, i * screenHeight);
+          }, i, screenHeight);
+
           const screen = await page.screenshot({
             path: totalHeight > screenHeight ? undefined : filePath, // if only 1 screen is needed with save immediately
             fullPage: false,


### PR DESCRIPTION
Enabling `mergeImgHack` was resulting in whitespace being produced for all but the first screenshot. To resolve this I discovered that the page needed to be scrolled to the appropriate part of the page for the screen.

It's not entirely clear to me why this is needed, I did a lot of exploring in the debug browser window to figure out if there was a better solution but I couldn't find anything although I'm sure there must be.

For comparison here is a before & after capture of netflix's homepage:

| Master      | This branch |
| ----------- | ----------- |
| ![netflixcom_desktop-old](https://user-images.githubusercontent.com/117200/103887979-debe3780-50db-11eb-972a-a70400e7f3d1.png)      | ![netflixcom_desktop](https://user-images.githubusercontent.com/117200/103887994-e2ea5500-50db-11eb-9272-0399c9f76d49.png)       |


Fixes #1267