### PR TITLE
refactor(waitFor): replaced .waitFor by its successor .waitForTimeout

### DIFF
--- a/capture/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/capture/engine_scripts/puppet/clickAndHoverHelper.js
@@ -7,31 +7,31 @@ module.exports = async (page, scenario) => {
 
   if (keyPressSelector) {
     for (const keyPressSelectorItem of [].concat(keyPressSelector)) {
-      await page.waitFor(keyPressSelectorItem.selector);
+      await page.waitForTimeout(keyPressSelectorItem.selector);
       await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
     }
   }
 
   if (hoverSelector) {
     for (const hoverSelectorIndex of [].concat(hoverSelector)) {
-      await page.waitFor(hoverSelectorIndex);
+      await page.waitForTimeout(hoverSelectorIndex);
       await page.hover(hoverSelectorIndex);
     }
   }
 
   if (clickSelector) {
     for (const clickSelectorIndex of [].concat(clickSelector)) {
-      await page.waitFor(clickSelectorIndex);
+      await page.waitForTimeout(clickSelectorIndex);
       await page.click(clickSelectorIndex);
     }
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForTimeout(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -132,13 +132,13 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
 
     // --- WAIT FOR SELECTOR ---
     if (scenario.readySelector) {
-      await page.waitFor(scenario.readySelector);
+      await page.waitForTimeout(scenario.readySelector);
     }
     //
 
     // --- DELAY ---
     if (scenario.delay > 0) {
-      await page.waitFor(scenario.delay);
+      await page.waitForTimeout(scenario.delay);
     }
 
     // --- REMOVE SELECTORS ---

--- a/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -4,16 +4,16 @@ module.exports = async (page, scenario) => {
   const postInteractionWait = scenario.postInteractionWait; // selector [str] | ms [int]
 
   if (hoverSelector) {
-    await page.waitFor(hoverSelector);
+    await page.waitForTimeout(hoverSelector);
     await page.hover(hoverSelector);
   }
 
   if (clickSelector) {
-    await page.waitFor(clickSelector);
+    await page.waitForTimeout(clickSelector);
     await page.click(clickSelector);
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 };

--- a/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -6,24 +6,24 @@ module.exports = async (page, scenario) => {
 
   if (hoverSelector) {
     for (const hoverSelectorIndex of [].concat(hoverSelector)) {
-      await page.waitFor(hoverSelectorIndex);
+      await page.waitForTimeout(hoverSelectorIndex);
       await page.hover(hoverSelectorIndex);
     }
   }
 
   if (clickSelector) {
     for (const clickSelectorIndex of [].concat(clickSelector)) {
-      await page.waitFor(clickSelectorIndex);
+      await page.waitForTimeout(clickSelectorIndex);
       await page.click(clickSelectorIndex);
     }
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForTimeout(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);

--- a/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -7,27 +7,27 @@ module.exports = async (page, scenario) => {
 
   if (keyPressSelector) {
     for (const keyPressSelectorItem of [].concat(keyPressSelector)) {
-      await page.waitFor(keyPressSelectorItem.selector);
+      await page.waitForTimeout(keyPressSelectorItem.selector);
       await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
     }
   }
 
   if (hoverSelector) {
-    await page.waitFor(hoverSelector);
+    await page.waitForTimeout(hoverSelector);
     await page.hover(hoverSelector);
   }
 
   if (clickSelector) {
-    await page.waitFor(clickSelector);
+    await page.waitForTimeout(clickSelector);
     await page.click(clickSelector);
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForTimeout(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);


### PR DESCRIPTION
> waitFor is deprecated and will be removed in a future release. See https://github.com/puppeteer/puppeteer/issues/6214 for details and how to migrate your code.

Fixes #1276