### PR TITLE
page.waitFor is deprecated

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -131,13 +131,13 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
 
     // --- WAIT FOR SELECTOR ---
     if (scenario.readySelector) {
-      await page.waitFor(scenario.readySelector);
+      await page.waitForSelector(scenario.readySelector);
     }
     //
 
     // --- DELAY ---
     if (scenario.delay > 0) {
-      await page.waitFor(scenario.delay);
+      await page.waitForTimeout(scenario.delay);
     }
 
     // --- REMOVE SELECTORS ---


### PR DESCRIPTION
page.waitFor is deprecated and should be replaces with page.waitForSelector or page.waitForTimeout

Removes warning 

```
waitFor is deprecated and will be removed in a future release. See https://github.com/puppeteer/puppeteer/issues/6214 for details and how to migrate your code.
```