### PR TITLE
Fix typo on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ hoverSelector            // Move the pointer over the specified DOM element prio
 hoverSelectors           // *Puppeteer only* takes array of selectors -- simulates multiple sequential hover interactions.
 clickSelector            // Click the specified DOM element prior to screen shot.
 clickSelectors           // *Puppeteer only* takes array of selectors -- simulates multiple sequential click interactions.
-postInteractionWait      // Wait for a selector after interacting with hoverSelector or clickSelector (optionally accepts wait time in ms. Idea for use with a click or hover element transition. available with default onReadyScript)
+postInteractionWait      // Wait for a selector after interacting with hoverSelector or clickSelector (optionally accepts wait time in ms. Ideal for use with a click or hover element transition. available with default onReadyScript)
 scrollToSelector         // Scrolls the specified DOM element into view prior to screen shot (available with default onReadyScript)
 selectors                // Array of selectors to capture. Defaults to document if omitted. Use "viewport" to capture the viewport size. See Targeting elements in the next section for more info...
 selectorExpansion        // See Targeting elements in the next section for more info...


### PR DESCRIPTION
Hi, @garris,

Here's a small contribution.

A student had doubts about the usage of `hoverSelector`, then I went to the docs and noticed this small typo on `postInteractionWait`'s comment. 😉 

👋🏻 