### PR TITLE
Feature/archive report

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ selectorExpansion        // See Targeting elements in the next section for more 
 misMatchThreshold        // Percentage of different pixels allowed to pass test
 requireSameDimensions    // If set to true -- any change in selector size will trigger a test failure.
 viewports                // An array of screen size objects your DOM will be tested against. This configuration will override the viewports property assigned at the config root.
+archiveReport            // If set to true -- all test reports will be archived(copied) (in `reports` folder)   
 ```
 
 
@@ -482,7 +483,7 @@ module.exports = async (page, scenario, vp) => {
 
 #### Setting the base path for custom onBefore and onReady scripts
 
-By default the base path is a folder called `engine_scripts` inside your BackstopJS installation directory. You can override this by setting the `paths.scripts` property in your `backstop.json` file to point to somewhere in your project directory (recommended).
+By default, the base path is a folder called `engine_scripts` inside your BackstopJS installation directory. You can override this by setting the `paths.scripts` property in your `backstop.json` file to point to somewhere in your project directory (recommended).
 
 ```json
 "paths": {
@@ -573,7 +574,8 @@ By default, BackstopJS saves generated resources into the `backstop_data` direct
     "engine_scripts": "backstop_data/engine_scripts",
     "html_report": "backstop_data/html_report",
     "json_report": "backstop_data/json_report",
-    "ci_report": "backstop_data/ci_report"
+    "ci_report": "backstop_data/ci_report",
+    "reports_archive": "backstop_data/reports",
   }
   ...
 ```

--- a/core/command/report.js
+++ b/core/command/report.js
@@ -51,7 +51,11 @@ function archiveReport (config) {
 
   return fs.copy(toAbsolute(config.html_report), archivePath).then(function () {
     const file = path.join(archivePath, path.basename(config.compareConfigFileName));
-    return replaceInFile(file, /"..\\\\/g, '"../../');
+    // replace the "..\\" with "..\\..\\" in the config.js files
+    // on windows double escape in order to work properly
+    const search = path.sep.replace(/\\/g, '\\\\\\\\');
+    const replace = path.sep.replace(/\\/g, '\\\\');
+    return replaceInFile(file, new RegExp(`"..${search}`, 'g'), `"..${replace}..${replace}`);
   });
 }
 

--- a/core/command/report.js
+++ b/core/command/report.js
@@ -7,6 +7,23 @@ const fs = require('../util/fs');
 const logger = require('../util/logger')('report');
 const compare = require('../util/compare/');
 
+function replaceInFile (file, search, replace) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', function (err, data) {
+      if (err) {
+        reject(err);
+      }
+      const result = data.replace(search, replace);
+
+      fs.writeFile(file, result, 'utf8', function (err) {
+        if (err) reject(err);
+      }).then(() => {
+        resolve();
+      });
+    });
+  });
+}
+
 function writeReport (config, reporter) {
   const promises = [];
 
@@ -23,6 +40,21 @@ function writeReport (config, reporter) {
   return allSettled(promises);
 }
 
+function archiveReport (config) {
+  let archivePath = path.join(config.archivePath, config.screenshotDateTime);
+
+  function toAbsolute (p) {
+    return (path.isAbsolute(p)) ? p : path.join(config.projectPath, p);
+  }
+
+  archivePath = toAbsolute(archivePath);
+
+  return fs.copy(toAbsolute(config.html_report), archivePath).then(function () {
+    const file = path.join(archivePath, path.basename(config.compareConfigFileName));
+    return replaceInFile(file, /"..\\\\/g, '"../../');
+  });
+}
+
 function writeBrowserReport (config, reporter) {
   let testConfig;
   if (typeof config.args.config === 'object') {
@@ -36,6 +68,7 @@ function writeBrowserReport (config, reporter) {
   function toAbsolute (p) {
     return (path.isAbsolute(p)) ? p : path.join(config.projectPath, p);
   }
+
   logger.log('Writing browser report');
 
   return fs.copy(config.comparePath, toAbsolute(config.html_report)).then(function () {
@@ -88,7 +121,13 @@ function writeBrowserReport (config, reporter) {
       throw err;
     });
 
-    return allSettled([jsonpConfgWrite, jsonConfgWrite]);
+    let promises = [jsonpConfgWrite, jsonConfgWrite];
+
+    if (config.archiveReport) {
+      promises.push(archiveReport(config));
+    }
+
+    return allSettled(promises);
   }).then(function () {
     if (config.openReport && config.report && config.report.indexOf('browser') > -1) {
       const executeCommand = require('./index');
@@ -143,6 +182,7 @@ function writeJsonReport (config, reporter) {
   function toAbsolute (p) {
     return (path.isAbsolute(p)) ? p : path.join(config.projectPath, p);
   }
+
   logger.log('Writing json report');
   return fs.ensureDir(toAbsolute(config.json_report)).then(function () {
     logger.log('Resources copied');

--- a/core/command/report.js
+++ b/core/command/report.js
@@ -125,14 +125,14 @@ function writeBrowserReport (config, reporter) {
       throw err;
     });
 
-    let promises = [jsonpConfgWrite, jsonConfgWrite];
-
-    if (config.archiveReport) {
-      promises.push(archiveReport(config));
-    }
+    const promises = [jsonpConfgWrite, jsonConfgWrite];
 
     return allSettled(promises);
   }).then(function () {
+    if (config.archiveReport) {
+      archiveReport(config);
+    }
+
     if (config.openReport && config.report && config.report.indexOf('browser') > -1) {
       const executeCommand = require('./index');
       return executeCommand('_openReport', config);

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -58,6 +58,8 @@ function ci (config, userConfig) {
 function htmlReport (config, userConfig) {
   config.html_report = path.join(config.projectPath, 'backstop_data', 'html_report');
   config.openReport = userConfig.openReport === undefined ? true : userConfig.openReport;
+  config.archivePath = path.join(config.projectPath, 'backstop_data', 'reports');
+  config.archiveReport = userConfig.archiveReport === undefined ? false : userConfig.archiveReport;
 
   if (userConfig.paths) {
     config.html_report = userConfig.paths.html_report || config.html_report;

--- a/core/util/extendConfig.js
+++ b/core/util/extendConfig.js
@@ -63,6 +63,7 @@ function htmlReport (config, userConfig) {
 
   if (userConfig.paths) {
     config.html_report = userConfig.paths.html_report || config.html_report;
+    config.archivePath = userConfig.paths.reports_archive || config.archivePath;
   }
 
   config.compareConfigFileName = path.join(config.html_report, 'config.js');

--- a/test/configs/backstop.json
+++ b/test/configs/backstop.json
@@ -49,5 +49,6 @@
   "asyncCaptureLimit": 5,
   "asyncCompareLimit": 50,
   "debug": false,
-  "debugWindow": false
+  "debugWindow": false,
+  "archiveReport": true
 }

--- a/test/core/util/makeConfig_it_spec.js
+++ b/test/core/util/makeConfig_it_spec.js
@@ -38,7 +38,9 @@ const expectedConfig = {
   defaultMisMatchThreshold: 0.1,
   debug: false,
   resembleOutputOptions: undefined,
-  dockerCommandTemplate: undefined
+  dockerCommandTemplate: undefined,
+  archivePath: path.resolve('backstop_data/reports'),
+  archiveReport: false
 };
 
 describe('make config it', function () {


### PR DESCRIPTION
Archive reports functionality. Based on #1349. 

@garris please review the config variable naming's, I am not 100% happy yet. 

We'll need 2 variables:
 - `archiveReport:true/false`
 - and in "paths"
```
"paths": {
...
    "reports_archive": "backstop_data/reports",
  }
```
The reports are generated in `reports` folder, see screenshot:
![Screenshot_8](https://user-images.githubusercontent.com/944350/129474944-adfd02d3-2a5f-4ede-aaed-4369122ba547.png)
