### PR TITLE
- Disable Cache on client side

### DIFF
--- a/compare/output/index.html
+++ b/compare/output/index.html
@@ -2,6 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <!-- Disable Cache -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+
     <title>BackstopJS Report</title>
 
     <style>


### PR DESCRIPTION
Reason: 

We set it to no cache in the report, because on github pages we don't have control over the caching strategy. 

Caching here is not needed. 

https://github.com/garris/BackstopJS/issues/1352
