### PR TITLE
Fixed Puppeteer ENOENT Error When Image Stubbing

### DIFF
--- a/capture/engine_scripts/puppet/interceptImages.js
+++ b/capture/engine_scripts/puppet/interceptImages.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const path = require('path');
 
 const IMAGE_URL_RE = /\.gif|\.jpg|\.png/i;
-const IMAGE_STUB_URL = path.resolve(__dirname, '../../imageStub.jpg');
+const IMAGE_STUB_URL = path.resolve(__dirname, '../imageStub.jpg');
 const IMAGE_DATA_BUFFER = fs.readFileSync(IMAGE_STUB_URL);
 const HEADERS_STUB = {};
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50255197/142158362-976cbba5-f145-4f6b-8094-a1ab24e97fb6.png)

The imageStub.jpg file is only one folder back from the interceptImages.js file. So, I removed the extra `../` so that it can reference the image.

Verified this resolved the Puppeteer ENOENT error message, and Backstop is successfully stubbing images on my computer now.