### PR TITLE
Click all found elements with clickSelector

### DIFF
--- a/capture/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/capture/engine_scripts/puppet/clickAndHoverHelper.js
@@ -22,7 +22,11 @@ module.exports = async (page, scenario) => {
   if (clickSelector) {
     for (const clickSelectorIndex of [].concat(clickSelector)) {
       await page.waitFor(clickSelectorIndex);
-      await page.click(clickSelectorIndex);
+      await page.evaluate(clickSelectorIndex => {
+				for (var element of document.querySelectorAll(clickSelectorIndex)) {
+					element.click();
+				}
+			}, clickSelectorIndex);
     }
   }
 


### PR DESCRIPTION
Fix for clickSelector only clicking the first element found, should click all found elements.