### PR TITLE
Update to latest node LTS: 16.14.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.3
+FROM node:16.14.0
 
 ARG BACKSTOPJS_VERSION
 
@@ -29,6 +29,7 @@ RUN apt-get -qqy update \
     fonts-liberation \
     fonts-ipafont-gothic \
     fonts-wqy-zenhei \
+    libgbm-dev \
     gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get -qyy clean


### PR DESCRIPTION
I built this locally and my project's tests still run using the built image after the upgrade.
Is there any other testing you would want doing on this?

It does include an upgrade to a new version of Debian as the node 16 image uses a new major release .