### PR TITLE
bugfix(playwright): timeout for elements without height

### DIFF
--- a/core/util/runPlaywright.js
+++ b/core/util/runPlaywright.js
@@ -144,7 +144,8 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     // --- WAIT FOR SELECTOR ---
     if (scenario.readySelector) {
       await page.waitForSelector(scenario.readySelector, {
-        timeout: readyTimeout
+        timeout: readyTimeout,
+        state: 'attached'
       });
     }
     //


### PR DESCRIPTION
If `selectors` targets elements without height (e.g. child elements with `position: absolute|fixed|sticky`),
it times out when using Playwright as the Engine.

Extend global `page.waitForSelector` for `readySelector` with `state: 'attached'` which should ensure that the element is in DOM.

Puppeteer does not have this issue and does not allow this option in `waitForSelector` ([Puppeteer Docs](https://pptr.dev/#?product=Puppeteer&show=api-pagewaitforselectorselector-options))

[Playwright Docs](https://playwright.dev/docs/api/class-page#page-wait-for-selector)