### PR TITLE
chore: update playwright from 1.17.1 to 1.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1951,6 +1951,11 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5977,11 +5982,11 @@
       }
     },
     "playwright": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.17.1.tgz",
-      "integrity": "sha512-DisCkW9MblDJNS3rG61p8LiLA2WA7IY/4A4W7DX4BphWe/HuWjKmGQptuk4NVIh5UuSwXpW/jaH2+ZgjHs3GMA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.20.0.tgz",
+      "integrity": "sha512-YcFXhXttk9yvpc8PMbfvts6KEopXjxdBh47BdOiA7xhjF/gkXeSM0Hs9CSdbL9mp2xtlB5xqE7+D+F2soQOjbA==",
       "requires": {
-        "playwright-core": "=1.17.1"
+        "playwright-core": "1.20.0"
       },
       "dependencies": {
         "commander": {
@@ -5998,37 +6003,54 @@
           }
         },
         "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+        },
+        "pixelmatch": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
+          "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
+          "requires": {
+            "pngjs": "^4.0.1"
+          },
+          "dependencies": {
+            "pngjs": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
+              "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg=="
+            }
+          }
         },
         "playwright-core": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.17.1.tgz",
-          "integrity": "sha512-C3c8RpPiC3qr15fRDN6dx6WnUkPLFmST37gms2aoHPDRvp7EaGDPMMZPpqIm/QWB5J40xDrQCD4YYHz2nBTojQ==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
+          "integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
           "requires": {
-            "commander": "^8.2.0",
-            "debug": "^4.1.1",
-            "extract-zip": "^2.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "jpeg-js": "^0.4.2",
-            "mime": "^2.4.6",
-            "pngjs": "^5.0.0",
-            "progress": "^2.0.3",
-            "proper-lockfile": "^4.1.1",
-            "proxy-from-env": "^1.1.0",
-            "rimraf": "^3.0.2",
-            "socks-proxy-agent": "^6.1.0",
-            "stack-utils": "^2.0.3",
-            "ws": "^7.4.6",
-            "yauzl": "^2.10.0",
-            "yazl": "^2.5.1"
+            "colors": "1.4.0",
+            "commander": "8.3.0",
+            "debug": "4.3.3",
+            "extract-zip": "2.0.1",
+            "https-proxy-agent": "5.0.0",
+            "jpeg-js": "0.4.3",
+            "mime": "3.0.0",
+            "pixelmatch": "5.2.1",
+            "pngjs": "6.0.0",
+            "progress": "2.0.3",
+            "proper-lockfile": "4.1.2",
+            "proxy-from-env": "1.1.0",
+            "rimraf": "3.0.2",
+            "socks-proxy-agent": "6.1.1",
+            "stack-utils": "2.0.5",
+            "ws": "8.4.2",
+            "yauzl": "2.10.0",
+            "yazl": "2.5.1"
           }
         },
         "pngjs": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+          "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
         },
         "rimraf": {
           "version": "3.0.2",
@@ -7529,12 +7551,12 @@
       }
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "requires": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "smart-buffer": "^4.2.0"
       }
     },
     "socks-proxy-agent": {
@@ -7548,9 +7570,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -9006,9 +9028,9 @@
       }
     },
     "ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA=="
     },
     "xmlbuilder": {
       "version": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "os": "^0.1.2",
     "p-map": "^1.2.0",
     "path": "^0.12.7",
-    "playwright": "^1.17.1",
+    "playwright": "^1.20.0",
     "portfinder": "^1.0.28",
     "puppeteer": "^13.5.1",
     "super-simple-web-server": "^1.1.2",


### PR DESCRIPTION
Thank you for merging https://github.com/garris/BackstopJS/pull/1403. This PR includes another dependency update that would be much appreciated.

In one of my projects I use playwright for my E2E tests and as an engine in backstop. With the latest release of playwright the version difference between 1.20 (the latest) and the bundled backstop version (1.17.1) seems to be too large. After using playwright 1.20 to install the browsers, backstops playwright 1.17.1 can't find them.

I tried out this PR in my project and it resolves this issue.