### PR TITLE
README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ By default, the base path is a folder called `engine_scripts` inside your Backst
 onBefore(page, scenario, viewport, isReference, Engine, config)
 
 ```
-engine:      browser page object
+page:      browser page object
 scenario:    currently running scenario config
 viewport:    viewport info
 isReference: whether scenario contains reference URL property


### PR DESCRIPTION
On line 501 the variable was mislabeled "engine", but on line 498 it is mentioned as "page"