### PR TITLE
Quick fix for early disposal of playwright browser

### DIFF
--- a/core/util/runPlaywright.js
+++ b/core/util/runPlaywright.js
@@ -254,7 +254,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     try {
       compareConfig = await delegateSelectors(
         page,
-        browser,
+        browserContext,
         scenario,
         viewport,
         variantOrScenarioLabelSafe,


### PR DESCRIPTION
Pass the browserContext instead of the browser instance.  See comment https://github.com/garris/BackstopJS/pull/1417#issuecomment-1121303500 