### PR TITLE
Remote command : compatibility with Windows

### DIFF
--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -11,11 +11,12 @@ module.exports = {
 
     return new Promise(function (resolve, reject) {
       const port = getRemotePort();
-      const commandStr = `SSWS_HTTP_PORT=${port} node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
+      const commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
+	    const env = {'SSWS_HTTP_PORT': port};
 
-      logger.log(`Starting remote with: ${commandStr}`);
+      logger.log(`Starting remote with: ${commandStr} with env ${JSON.stringify(env)}`);
 
-      const child = exec(commandStr);
+      const child = exec(commandStr, {env: env});
 
       child.stdout.on('data', logger.log);
 


### PR DESCRIPTION
Remote command doesn't work anymore on Windows after the PR #1439
Indeed, we can't use same code to add env variables to command on Linux and Windows.
So using the exec command env option.