### PR TITLE
Remove usage of deprecated/removed waitFor in clickAndHoverHelper scripts

### DIFF
--- a/capture/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/capture/engine_scripts/puppet/clickAndHoverHelper.js
@@ -7,31 +7,31 @@ module.exports = async (page, scenario) => {
 
   if (keyPressSelector) {
     for (const keyPressSelectorItem of [].concat(keyPressSelector)) {
-      await page.waitFor(keyPressSelectorItem.selector);
+      await page.waitForSelector(keyPressSelectorItem.selector);
       await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
     }
   }
 
   if (hoverSelector) {
     for (const hoverSelectorIndex of [].concat(hoverSelector)) {
-      await page.waitFor(hoverSelectorIndex);
+      await page.waitForSelector(hoverSelectorIndex);
       await page.hover(hoverSelectorIndex);
     }
   }
 
   if (clickSelector) {
     for (const clickSelectorIndex of [].concat(clickSelector)) {
-      await page.waitFor(clickSelectorIndex);
+      await page.waitForSelector(clickSelectorIndex);
       await page.click(clickSelectorIndex);
     }
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForSelector(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);

--- a/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -4,16 +4,16 @@ module.exports = async (page, scenario) => {
   const postInteractionWait = scenario.postInteractionWait; // selector [str] | ms [int]
 
   if (hoverSelector) {
-    await page.waitFor(hoverSelector);
+    await page.waitForSelector(hoverSelector);
     await page.hover(hoverSelector);
   }
 
   if (clickSelector) {
-    await page.waitFor(clickSelector);
+    await page.waitForSelector(clickSelector);
     await page.click(clickSelector);
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 };

--- a/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -6,24 +6,24 @@ module.exports = async (page, scenario) => {
 
   if (hoverSelector) {
     for (const hoverSelectorIndex of [].concat(hoverSelector)) {
-      await page.waitFor(hoverSelectorIndex);
+      await page.waitForSelector(hoverSelectorIndex);
       await page.hover(hoverSelectorIndex);
     }
   }
 
   if (clickSelector) {
     for (const clickSelectorIndex of [].concat(clickSelector)) {
-      await page.waitFor(clickSelectorIndex);
+      await page.waitForSelector(clickSelectorIndex);
       await page.click(clickSelectorIndex);
     }
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForSelector(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);

--- a/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -7,27 +7,27 @@ module.exports = async (page, scenario) => {
 
   if (keyPressSelector) {
     for (const keyPressSelectorItem of [].concat(keyPressSelector)) {
-      await page.waitFor(keyPressSelectorItem.selector);
+      await page.waitForSelector(keyPressSelectorItem.selector);
       await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
     }
   }
 
   if (hoverSelector) {
-    await page.waitFor(hoverSelector);
+    await page.waitForSelector(hoverSelector);
     await page.hover(hoverSelector);
   }
 
   if (clickSelector) {
-    await page.waitFor(clickSelector);
+    await page.waitForSelector(clickSelector);
     await page.click(clickSelector);
   }
 
   if (postInteractionWait) {
-    await page.waitFor(postInteractionWait);
+    await page.waitForTimeout(postInteractionWait);
   }
 
   if (scrollToSelector) {
-    await page.waitFor(scrollToSelector);
+    await page.waitForSelector(scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, scrollToSelector);


### PR DESCRIPTION
Puppeteer deprecated and by now, removed `page.waitFor()` (see puppeteer/puppeteer#6214). This results in `TypeError: page.waitFor is not a function` when using things like `postInteractionWait`, `clickSelector` and similar features relying on `clickAndHoverHelper.js`. See #1431 for details.

You can observe this issue when running `npm run smoke-test`:

<img width="1748" alt="Screenshot 2022-10-09 at 12 31 02" src="https://user-images.githubusercontent.com/540525/194739720-206ec8a6-8253-435f-bf5b-f3dfaef9b7e3.png">

This PR fixes all usage of `waitFor` in examples, tests and templates used for `backstop init`. 

Projects that ran `backstop init` would still need to change their version of the scripts themselves but at least for new usages, this issue would be fixed (and existing users would have a guide what a fixed version would look like)

(by the way, it's Hacktoberfest so consider opting in by [adding a `hacktoberfest` topic to the repo](https://hacktoberfest.com/participation/#maintainers) before merging PRs to give contributors a chance for a tiny reward 😄 )

