### PR TITLE
Allow to modify  `gotoParameters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ selectorExpansion        // See Targeting elements in the next section for more 
 misMatchThreshold        // Percentage of different pixels allowed to pass test
 requireSameDimensions    // If set to true -- any change in selector size will trigger a test failure.
 viewports                // An array of screen size objects your DOM will be tested against. This configuration will override the viewports property assigned at the config root.
+gotoParameters           // An array of settings passed to page.goto(url, parameters) function.
 ```
 <!-- archiveReport            // If set to true -- all test reports will be archived(copied) (in `reports` folder)  -->
 
@@ -644,7 +645,8 @@ You can add more settings (or override the defaults) with the engineOptions prop
 ```json
 "engineOptions": {
   "ignoreHTTPSErrors": false,
-  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"],
+  "gotoParameters": { "waitUntil": "networkidle0" },
 }
 ```
 More info here:

--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -12,7 +12,7 @@ module.exports = {
     return new Promise(function (resolve, reject) {
       const port = getRemotePort();
       const commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
-	    const env = {'SSWS_HTTP_PORT': port};
+      const env = {'SSWS_HTTP_PORT': port};
 
       logger.log(`Starting remote with: ${commandStr} with env ${JSON.stringify(env)}`);
 

--- a/core/util/runPlaywright.js
+++ b/core/util/runPlaywright.js
@@ -135,7 +135,9 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     if (isReference && scenario.referenceUrl) {
       url = scenario.referenceUrl;
     }
-    await page.goto(translateUrl(url));
+
+    const gotoParameters = scenario?.engineOptions?.gotoParameters || config?.engineOptions?.gotoParameters || {};
+    await page.goto(translateUrl(url), gotoParameters);
 
     await injectBackstopTools(page);
 

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -138,7 +138,9 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     if (isReference && scenario.referenceUrl) {
       url = scenario.referenceUrl;
     }
-    await page.goto(translateUrl(url, logger));
+
+    const gotoParameters = scenario?.engineOptions?.gotoParameters || config?.engineOptions?.gotoParameters || {};
+    await page.goto(translateUrl(url, logger), gotoParameters);
 
     await injectBackstopTools(page);
 

--- a/examples/responsiveDemo/backstop_data/engine_scripts/puppet/ignoreCSP.js
+++ b/examples/responsiveDemo/backstop_data/engine_scripts/puppet/ignoreCSP.js
@@ -36,7 +36,7 @@ module.exports = async function (page, scenario) {
       const cookies = cookiesList.map(cookie => `${cookie.name}=${cookie.value}`).join('; ');
       const headers = Object.assign(request.headers(), { cookie: cookies });
       const options = {
-        headers: headers,
+        headers,
         body: request.postData(),
         method: request.method(),
         follow: 20,


### PR DESCRIPTION
This PR will introduce a new option for both scenarios or the general `engineOptions` parameter.

It will allow users to modify both Puppeteer and Playwright parameters on `page.goto(url, parameters)`.

## Examples

1. Modify general engine options

```json
"engineOptions": {
  "gotoParameters": { "waitUntil": "networkidle0" },
}
```

2. Modify engine options for a single scenario

```json

"scenarios": [
  {
    "label": "domcontentloaded",
    "url": "https://example.com"
    "gotoParameters": { "waitUntil": "domcontentloaded" },
  }
]
```

### But why?

I've noticed that the default `waitUntil` parameter for Playwright which is the `load` value is not enough when BackstopJS is creating images for my website. In order to fix it I had to create a patch. I'd like to add it to the core as my piece of contribution. 

This PR also fixes some small coding standards issues in the `core/command/remote.js` file.