### PR TITLE
fix permission problem with local bind mount (#1466)

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ The above flag will cause BackstopJS to hit your Docker local client, spin up a 
 If the default docker command or image does not work for you, you can customize the command to run BackstopJS with Docker by changing the `dockerCommandTemplate` config option. The default is:
 
 ```sh
-"dockerCommandTemplate": "docker run --rm -it --mount type=bind,source=\"{cwd}\",target=/src backstopjs/backstopjs:{version} {backstopCommand} {args}"
+"dockerCommandTemplate": "docker run --rm -it --user $(id -u):$(id -g) --mount type=bind,source=\"{cwd}\",target=/src backstopjs/backstopjs:{version} {backstopCommand} {args}"
 ```
 
 

--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -2,7 +2,7 @@ const { spawn } = require('child_process');
 const version = require('../../package').version;
 const fs = require('./fs');
 
-const DEFAULT_DOCKER_COMMAND_TEMPLATE = 'docker run --rm -it --mount type=bind,source="{cwd}",target=/src backstopjs/backstopjs:{version} {backstopCommand} {args}';
+const DEFAULT_DOCKER_COMMAND_TEMPLATE = 'docker run --rm -it --user $(id -u):$(id -g) --mount type=bind,source="{cwd}",target=/src backstopjs/backstopjs:{version} {backstopCommand} {args}';
 
 module.exports.shouldRunDocker = (config) => config.args.docker;
 


### PR DESCRIPTION
npm run sanity-test-docker
npm run smoke-test-docker

both are able to run now without permission problems.