### PR TITLE
fix(remote): updates `child_process.exec` to include PATH and log errors

### DIFF
--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -16,7 +16,11 @@ module.exports = {
 
       logger.log(`Starting remote with: ${commandStr} with env ${JSON.stringify(env)}`);
 
-      const child = exec(commandStr, {env: env});
+      const child = exec(commandStr, { env: { ...env, 'PATH': process.env.PATH } }, (error) => {
+        if (error) {
+          console.log("Error running backstop remote:", error);
+        }
+      });
 
       child.stdout.on('data', logger.log);
 

--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -18,7 +18,7 @@ module.exports = {
 
       const child = exec(commandStr, { env: { ...env, 'PATH': process.env.PATH } }, (error) => {
         if (error) {
-          console.log("Error running backstop remote:", error);
+          logger.log("Error running backstop remote:", error);
         }
       });
 


### PR DESCRIPTION
closes #1446 

`child_process.exec` isn't aware of the `node` executable path without explicitly including the parent process's `PATH`

Also added logging for `exec` so errors are a little easier to access by downstream users.

_Note: this is likely only for local, `npm i -D backstopjs`, use cases._