### PR TITLE
fix(remote): allows the `ApproveButton` component to get its port num…

### DIFF
--- a/compare/src/components/molecules/ApproveButton.js
+++ b/compare/src/components/molecules/ApproveButton.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
-import getRemotePort from '../../../../core/util/getRemotePort';
 import { approveTest, filterTests } from '../../actions';
 import { colors, fonts } from '../../styles';
 
 const REMOTE_HOST = 'http://127.0.0.1';
-const REMOTE_PORT = getRemotePort();
+const REMOTE_PORT = location.port;
 const APPROVE_STATUS_TO_LABEL_MAP = Object.freeze({
   INITIAL: 'Approve',
   PENDING: 'Pending...',


### PR DESCRIPTION
…ber from the browser

currently this component is trying to read from `process.env.BACKSTOP_REMOTE_HTTP_PORT`, which the browser has no access to. not sure if the intent is for webpack to interpolate this value and output a string, but it currently isn't. let the browser do the work for you :)