### PR TITLE
feat(playwright/remote): adds support for `scenarioLogsInReports` to …

### DIFF
--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -11,7 +11,7 @@ module.exports = {
 
     return new Promise(function (resolve, reject) {
       const port = getRemotePort();
-      const commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
+      const commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName} --colors`;
       const env = {'SSWS_HTTP_PORT': port};
 
       logger.log(`Starting remote with: ${commandStr} with env ${JSON.stringify(env)}`);

--- a/core/util/runPlaywright.js
+++ b/core/util/runPlaywright.js
@@ -57,7 +57,17 @@ module.exports.runPlaywright = function (args) {
   config._outputFileFormatSuffix = '.' + ((config.outputFormat && config.outputFormat.match(/jpg|jpeg/)) || 'png');
   config._configId = config.id || engineTools.genHash(config.backstopConfigFileName);
 
-  return processScenarioView(scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, browser);
+  const logger = {
+    logged: []
+  };
+  Object.assign(logger, {
+    error: loggerAction.bind(logger, 'error'),
+    warn: loggerAction.bind(logger, 'warn'),
+    log: loggerAction.bind(logger, 'log'),
+    info: loggerAction.bind(logger, 'info')
+  });
+
+  return processScenarioView(scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, browser, logger);
 };
 
 module.exports.disposePlaywrightBrowser = async function (browser) {
@@ -65,7 +75,12 @@ module.exports.disposePlaywrightBrowser = async function (browser) {
   await browser.close();
 };
 
-async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, browser) {
+function loggerAction (action, color, message, ...rest) {
+  this.logged.push([action, color, message.toString(), JSON.stringify(rest)]);
+  console[action](chalk[color](message), ...rest);
+}
+
+async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenarioLabelSafe, viewport, config, browser, logger) {
   if (!config.paths) {
     config.paths = {};
   }
@@ -89,7 +104,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
   page.setDefaultNavigationTimeout(engineTools.getEngineOption(config, 'waitTimeout', TEST_TIMEOUT));
 
   if (isReference) {
-    console.log(chalk.blue('CREATING NEW REFERENCE FILE'));
+    logger.log('blue', 'CREATING NEW REFERENCE FILE');
   }
 
   // --- set up console output and ready event ---
@@ -101,7 +116,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
       readyResolve = resolve;
       // fire the ready event after the readyTimeout
       readyTimeoutTimer = setTimeout(() => {
-        console.error(chalk.red(`ReadyEvent not detected within readyTimeout limit. (${readyTimeout} ms)`), scenario.url);
+        logger.error('red', `ReadyEvent not detected within readyTimeout limit. (${readyTimeout} ms)`, scenario.url);
         resolve();
       }, readyTimeout);
     });
@@ -110,7 +125,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
   page.on('console', msg => {
     for (let i = 0; i < msg.args().length; ++i) {
       const line = msg.args()[i];
-      console.log(`Browser Console Log ${i}: ${line}`);
+      logger.log('reset', `Browser Console Log ${i}: ${line}`);
       if (readyEvent && new RegExp(readyEvent).test(line)) {
         readyResolve();
       }
@@ -126,7 +141,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
       if (fs.existsSync(beforeScriptPath)) {
         await require(beforeScriptPath)(page, scenario, viewport, isReference, browserContext, config);
       } else {
-        console.warn('WARNING: script not found: ' + beforeScriptPath);
+        logger.warn('reset', 'WARNING: script not found: ' + beforeScriptPath);
       }
     }
 
@@ -137,7 +152,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     }
 
     const gotoParameters = scenario?.engineOptions?.gotoParameters || config?.engineOptions?.gotoParameters || {};
-    await page.goto(translateUrl(url), gotoParameters);
+    await page.goto(translateUrl(url, logger), gotoParameters);
 
     await injectBackstopTools(page);
 
@@ -149,6 +164,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
 
       clearTimeout(readyTimeoutTimer);
 
+      // can't use logger here -- this executes on the page
       await page.evaluate(_ => console.info('readyEvent ok'));
     }
 
@@ -191,7 +207,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
       if (fs.existsSync(readyScriptPath)) {
         await require(readyScriptPath)(page, scenario, viewport, isReference, browserContext, config);
       } else {
-        console.warn('WARNING: script not found: ' + readyScriptPath);
+        logger.warn('reset', 'WARNING: script not found: ' + readyScriptPath);
       }
     }
 
@@ -247,8 +263,8 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
 
   let error;
   await playwrightCommands().catch(e => {
-    console.log(chalk.red(`Playwright encountered an error while running scenario "${scenario.label}"`));
-    console.log(chalk.red(e));
+    logger.log('red', `Playwright encountered an error while running scenario "${scenario.label}"`);
+    logger.log('red', e);
     error = e;
   });
 
@@ -264,7 +280,8 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
         scenarioLabelSafe,
         config,
         result.backstopSelectorsExp,
-        result.backstopSelectorsExpMap
+        result.backstopSelectorsExpMap,
+        logger
       );
     } catch (e) {
       error = e;
@@ -276,11 +293,13 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
   if (error) {
     const testPair = engineTools.generateTestPair(config, scenario, viewport, variantOrScenarioLabelSafe, scenarioLabelSafe, 0, `${scenario.selectors.join('__')}`);
     const filePath = config.isReference ? testPair.reference : testPair.test;
+    const logFilePath = config.isReference ? testPair.referenceLog : testPair.testLog;
     testPair.engineErrorMsg = error.message;
 
     compareConfig = {
       testPairs: [testPair]
     };
+    await writeScenarioLogs(config, logFilePath, logger);
     await fs.copy(config.env.backstop + ERROR_SELECTOR_PATH, filePath);
   }
 
@@ -297,7 +316,8 @@ async function delegateSelectors (
   scenarioLabelSafe,
   config,
   selectors,
-  selectorMap
+  selectorMap,
+  logger
 ) {
   const compareConfig = { testPairs: [] };
   let captureDocument = false;
@@ -308,12 +328,14 @@ async function delegateSelectors (
   selectors.forEach(function (selector, selectorIndex) {
     const testPair = engineTools.generateTestPair(config, scenario, viewport, variantOrScenarioLabelSafe, scenarioLabelSafe, selectorIndex, selector);
     const filePath = config.isReference ? testPair.reference : testPair.test;
+    const logFilePath = config.isReference ? testPair.referenceLog : testPair.testLog;
 
     if (!config.isReference) {
       compareConfig.testPairs.push(testPair);
     }
 
     selectorMap[selector].filePath = filePath;
+    selectorMap[selector].logFilePath = logFilePath;
     if (selector === BODY_SELECTOR || selector === DOCUMENT_SELECTOR) {
       captureDocument = selector;
     } else if (selector === VIEWPORT_SELECTOR) {
@@ -324,14 +346,14 @@ async function delegateSelectors (
   });
 
   if (captureDocument) {
-    captureJobs.push(function () { return captureScreenshot(page, browserContext, captureDocument, selectorMap, config, [], viewport); });
+    captureJobs.push(function () { return captureScreenshot(page, browserContext, captureDocument, selectorMap, config, [], viewport, logger); });
   }
   // TODO: push captureViewport into captureList (instead of calling captureScreenshot()) to improve perf.
   if (captureViewport) {
-    captureJobs.push(function () { return captureScreenshot(page, browserContext, captureViewport, selectorMap, config, [], viewport); });
+    captureJobs.push(function () { return captureScreenshot(page, browserContext, captureViewport, selectorMap, config, [], viewport, logger); });
   }
   if (captureList.length) {
-    captureJobs.push(function () { return captureScreenshot(page, browserContext, null, selectorMap, config, captureList, viewport); });
+    captureJobs.push(function () { return captureScreenshot(page, browserContext, null, selectorMap, config, captureList, viewport, logger); });
   }
 
   return new Promise(function (resolve, reject) {
@@ -348,7 +370,7 @@ async function delegateSelectors (
       }
       job = captureJobs.shift();
       job().catch(function (e) {
-        console.log(e);
+        logger.log('reset', e);
         errors.push(e);
       }).then(function () {
         next();
@@ -356,19 +378,20 @@ async function delegateSelectors (
     };
     next();
   }).then(async () => {
-    console.log(chalk.green('x Close Browser'));
+    logger.log('green', 'x Close Browser');
     await browserContext.close();
   }).catch(async (err) => {
-    console.log(chalk.red(err));
+    logger.log('red', err);
     await browserContext.close();
   }).then(_ => compareConfig);
 }
 
-async function captureScreenshot (page, browserContext, selector, selectorMap, config, selectors, viewport) {
-  let filePath;
+async function captureScreenshot (page, browserContext, selector, selectorMap, config, selectors, viewport, logger) {
+  let filePath, logFilePath;
   const fullPage = (selector === NOCLIP_SELECTOR || selector === DOCUMENT_SELECTOR);
   if (selector) {
     filePath = selectorMap[selector].filePath;
+    logFilePath = selectorMap[selector].logFilePath;
     ensureDirectoryPath(filePath);
 
     try {
@@ -376,13 +399,15 @@ async function captureScreenshot (page, browserContext, selector, selectorMap, c
         path: filePath,
         fullPage
       });
+      await writeScenarioLogs(config, logFilePath, logger);
     } catch (e) {
-      console.log(chalk.red('Error capturing..'), e);
+      logger.log('red', 'Error capturing..', e);
+      await writeScenarioLogs(config, logFilePath, logger);
       return fs.copy(config.env.backstop + ERROR_SELECTOR_PATH, filePath);
     }
   } else {
     // OTHER-SELECTOR screenshot
-    const selectorShot = async (s, path) => {
+    const selectorShot = async (s, path, logFilePath) => {
       const el = await page.$(s);
       if (el) {
         const box = await el.boundingBox();
@@ -402,12 +427,15 @@ async function captureScreenshot (page, browserContext, selector, selectorMap, c
           const params = { captureBeyondViewport: false, path };
 
           await type.screenshot(params);
+          await writeScenarioLogs(config, logFilePath, logger);
         } else {
-          console.log(chalk.yellow(`Element not visible for capturing: ${s}`));
+          logger.log('yellow', `Element not visible for capturing: ${s}`);
+          await writeScenarioLogs(config, logFilePath, logger);
           return fs.copy(config.env.backstop + HIDDEN_SELECTOR_PATH, path);
         }
       } else {
-        console.log(chalk.magenta(`Element not found for capturing: ${s}`));
+        logger.log('magenta', `Element not found for capturing: ${s}`);
+        await writeScenarioLogs(config, logFilePath, logger);
         return fs.copy(config.env.backstop + SELECTOR_NOT_FOUND_PATH, path);
       }
     };
@@ -416,11 +444,13 @@ async function captureScreenshot (page, browserContext, selector, selectorMap, c
       for (let i = 0; i < selectors.length; i++) {
         const selector = selectors[i];
         filePath = selectorMap[selector].filePath;
+        logFilePath = selectorMap[selector].logFilePath;
         ensureDirectoryPath(filePath);
         try {
-          await selectorShot(selector, filePath);
+          await selectorShot(selector, filePath, logFilePath);
         } catch (e) {
-          console.log(chalk.red(`Error capturing Element ${selector}`), e);
+          logger.log('red', `Error capturing Element ${selector}`, e);
+          await writeScenarioLogs(config, logFilePath, logger);
           return fs.copy(config.env.backstop + ERROR_SELECTOR_PATH, filePath);
         }
       }
@@ -430,13 +460,21 @@ async function captureScreenshot (page, browserContext, selector, selectorMap, c
 }
 
 // handle relative file name
-function translateUrl (url) {
+function translateUrl (url, logger) {
   const RE = /^[./]/;
   if (RE.test(url)) {
     const fileUrl = 'file://' + path.join(process.cwd(), url);
-    console.log('Relative filename detected -- translating to ' + fileUrl);
+    logger.log('reset', 'Relative filename detected -- translating to ' + fileUrl);
     return fileUrl;
   } else {
     return url;
+  }
+}
+
+function writeScenarioLogs (config, logFilePath, logger) {
+  if (config.scenarioLogsInReports) {
+    return fs.writeFile(logFilePath, JSON.stringify(logger.logged));
+  } else {
+    return Promise.resolve(true);
   }
 }


### PR DESCRIPTION
…playwright

- adds support for `scenarioLogsInReports` via `logger` and `writeScenarioLogs` in `runPlaywright.js`
- adds `--colors` flag to `child_process.exec` command because who doesn't like colors everywhere?

closes #1492