### PR TITLE
fix: adds headless ternary to handle 'new', true, and false in a non-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,12 +644,13 @@ ignoreHTTPSErrors: true,
 headless: <!!!config.debugWindow>
 ```
 
-You can add more settings (or override the defaults) with the engineOptions property. (properties are merged)
+You can add more settings (or override the defaults) with the engineOptions property. (properties are merged). This is where headless mode can also be set to 'new', until "new headless mode" is the default in Puppet/Playwright.
 
 ```json
 "engineOptions": {
   "ignoreHTTPSErrors": false,
   "args": ["--no-sandbox", "--disable-setuid-sandbox"],
+  "headless": "new",
   "gotoParameters": { "waitUntil": "networkidle0" },
 }
 ```

--- a/core/util/runPlaywright.js
+++ b/core/util/runPlaywright.js
@@ -36,7 +36,7 @@ module.exports.createPlaywrightBrowser = async function (config) {
   const playwrightArgs = Object.assign(
     {},
     {
-      headless: !config.debugWindow
+      headless: config.debugWindow ? false : config?.engineOptions?.headless || true
     },
     config.engineOptions
   );

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -71,7 +71,7 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     {},
     {
       ignoreHTTPSErrors: true,
-      headless: !config.debugWindow
+      headless: config.debugWindow ? false : config?.engineOptions?.headless || true
     },
     config.engineOptions
   );


### PR DESCRIPTION
…breaking fashion (#1485) (#1486)

_Adapted from conversation in #1485 and @Neychok's initial PR in #1486._

## Summary

Puppet and Playwright complain and pollute logs with warnings about "new headless mode". This reads the value set in backstop.json, or uses true if 'headless' is not set, or 'new', as a string. README updated with details.

## Tests

Updated all `./test/configs` with `headless: 'new'` and ran sanity tests. For example:

```shell
File: test/configs/backstop.json
46:   "engineOptions": {
47:     "args": ["--no-sandbox"],
48:     "headless": "new"
49:   },
```

Closes: #1485