### PR TITLE
chore: Upgrade base image to LTS version (Node 20)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # use bullseye node base, as debian does provide a chromium for arm64 and amd64 flavour
-FROM node:16-bullseye
+FROM node:20-bullseye
 
 ARG BACKSTOPJS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
closes: #1512