### PR TITLE
fix: use renamed 'makeConfig' method to fix 'integration-test' npm sc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ compare/output/bitmaps_test/
 compare/output/config\.js
 
 \.vscode/
+
+# Test-Generated Data
+newdir

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint \"compare/*.js\" \"compare/src/**/*.js\" \"core/**/*.js\" \"cli/**/*.js\" \"capture/**/*.js\" \"test/**/*.js\"",
     "format": "prettier-eslint --write \"compare/src/**/*.js\"",
-    "genConfig": "node ./cli/index.js genConfig",
+    "makeConfig": "node ./cli/index.js makeConfig",
     "init": "node ./cli/index.js init",
     "reference": "node ./cli/index.js reference",
     "test": "node ./cli/index.js test",
@@ -21,7 +21,7 @@
     "precommit": "lint-staged",
     "build-compare": "cp ./node_modules/diverged/src/diverged.js ./compare/output/ && cp ./node_modules/diff/dist/diff.js ./compare/output/ && webpack --config ./compare/webpack.config.js && npm run lint",
     "dev-compare": "webpack-dev-server --content-base ./compare/output --config ./compare/webpack.config.js",
-    "integration-test": "rm -rf newdir && mkdir newdir && cd newdir && node ../cli/index.js genConfig && node ../cli/index.js reference && node ../cli/index.js test && node -e \"require(\"../\")(\"test\")\"",
+    "integration-test": "rm -rf newdir && mkdir newdir && cd newdir && node ../cli/index.js init && node ../cli/index.js reference && node ../cli/index.js test && node -e \"require('../')('test')\"",
     "smoke-test": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features",
     "smoke-test-docker": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features --docker",
     "sanity-test": "cd test/configs/ && node ../../cli/index.js test",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "integration-test": "rm -rf newdir && mkdir newdir && cd newdir && node ../cli/index.js init && node ../cli/index.js reference && node ../cli/index.js test && node -e \"require('../')('test')\"",
     "smoke-test": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features",
     "smoke-test-docker": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features --docker",
+    "smoke-test-playwright-docker": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features_pw --docker",
+    "smoke-test-playwright": "cd test/configs/ && node ../../cli/index.js test --config=backstop_features_pw",
     "sanity-test": "cd test/configs/ && node ../../cli/index.js test",
     "sanity-test-docker": "cd test/configs/ && node ../../cli/index.js test --docker",
     "sanity-test-playwright-docker": "cd test/configs/ && node ../../cli/index.js test --config=playwright --docker",


### PR DESCRIPTION
…ript

also fixes eval syntax and .gitignores the generated 'newdir' test directory

I noticed `npm run integration-test` was no longer working. This was due to:

1. `genConfig` was renamed `init` and is accessed via `makeConfig` as seen in [this squash commit](https://github.com/garris/BackstopJS/commit/32db2a3c9a7113243ffb41f4c161c58c3c8d34c2#diff-945e9f448049242b2dade36efea1afba7a04e29ca7d06e88210af22138f0caee) in [32db2a3c](https://github.com/garris/BackstopJS/commit/32db2a3c9a7113243ffb41f4c161c58c3c8d34c2#diff-e4e27e88e2e75186d17ff5671736906d892c2fd9ffa674d7b2a82696018cadeaL34)
2. `eval` syntax was not being evaluated with the escaped quotes in `npm run integration-test`

Baby steps towards a larger update. @garris let me know if this needs any adjustments!

