### PR TITLE
ci(github): checks out head from  for PRs actions

### DIFF
--- a/.github/workflows/_backstop-docker-ci.yml
+++ b/.github/workflows/_backstop-docker-ci.yml
@@ -16,7 +16,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
 
 jobs:
   backstop-sanity-test:


### PR DESCRIPTION
@garris slight adjustment for GH action on PR - this should allow PRs to run and pull in the corresponding downstream branch properly.

I'll submit a PR with the `headless: new` change in a bit.

Thanks!