### PR TITLE
fix: use `github.event.pull_request.head.sha` for checkout@v4

### DIFF
--- a/.github/workflows/_backstop-docker-ci.yml
+++ b/.github/workflows/_backstop-docker-ci.yml
@@ -12,6 +12,7 @@ on:
     branches: [master, develop]
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write

--- a/.github/workflows/_backstop-docker-ci.yml
+++ b/.github/workflows/_backstop-docker-ci.yml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head.sha || github.head_ref || github.ref_name }}
 
 jobs:
   backstop-sanity-test:

--- a/.github/workflows/backstop-integration-test.yml
+++ b/.github/workflows/backstop-integration-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: ⬢ Setup Node & Cache
         uses: actions/setup-node@v4

--- a/.github/workflows/backstop-integration-test.yml
+++ b/.github/workflows/backstop-integration-test.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: ⬢ Setup Node & Cache
         uses: actions/setup-node@v4
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: ⬢ Setup Node & Cache
         uses: actions/setup-node@v4

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: ⬢ Setup Node & Cache
         uses: actions/setup-node@v4
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: ⬢ Setup Node & Cache
         uses: actions/setup-node@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set Name and Tag Vars
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set Name and Tag Vars
         env:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set Name and Tag Vars
         env:

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.sha_name || github.head_ref || github.ref_name }}
   NODE_VERSION: 20
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set Name and Tag Vars
         env:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set Name and Tag Vars
         env:

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write

--- a/.github/workflows/test-backstop.yml
+++ b/.github/workflows/test-backstop.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write


### PR DESCRIPTION
@garris trying something else for the failing GH actions — I recently updated the `checkout` action to v4, and see that one of [their examples](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit) uses `head.sha` instead of `head.ref`. 

Can we please give this a try?