### PR TITLE
feat: docker hub build/push action (#1546)

### DIFF
--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -1,0 +1,53 @@
+name: 🐳 Docker Hub Build & Push
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⇣ Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: 🏷️ Set Docker Image Tag
+        run: |
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci --verbose --foreground-scripts
+
+      - name: 🚢 Build Docker Builder
+        run: |
+          npm run --verbose --foreground-scripts init-docker-builder
+
+      - name: 🐳 Build & Push to Docker Hub
+        run: |
+          docker buildx build --push --platform linux/amd64,linux/arm64 -t backstopjs/backstopjs:$PV --build-arg BACKSTOPJS_VERSION=$PV docker


### PR DESCRIPTION
This adds a GitHub Workflow to build the multi-architecture Docker image, sign into Docker Hub, and push the image.

It uses the current `version` property in `package.json` as its tag, the same way `npm run build-and-publish` or `publish-docker` do.

### Requirements

1. Create a Docker Hub Access Token ([this link](https://hub.docker.com/settings/security?generateToken=true) will prompt you after login)
2. Add two Actions Secrets
  3. `DOCKERHUB_TOKEN`
  4. `DOCKERHUB_USERNAME`

![image](https://github.com/garris/BackstopJS/assets/445891/b5bce195-10d4-4500-9aee-3b8c187a4c97)

### Example

Here's the [workflow in action](https://github.com/dgrebb/BackstopJS/actions/runs/8012164310/job/21886901809). It fails because my Docker Hub account is not owner of backstopjs. Not the build successes for [amd](https://github.com/dgrebb/BackstopJS/actions/runs/8012164310/job/21886901809#step:8:1198) as well as [arm](https://github.com/dgrebb/BackstopJS/actions/runs/8012164310/job/21886901809#step:8:2232).

Hope this helps!