### PR TITLE
Change puppeteer's waitForTimeout into direct setTimeout

### DIFF
--- a/capture/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/capture/engine_scripts/puppet/clickAndHoverHelper.js
@@ -27,7 +27,9 @@ module.exports = async (page, scenario) => {
   }
 
   if (postInteractionWait) {
-    await page.waitForTimeout(postInteractionWait);
+    await new Promise(resolve => {
+      setTimeout(resolve, postInteractionWait);
+    });
   }
 
   if (scrollToSelector) {

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -175,7 +175,9 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
 
     // --- DELAY ---
     if (scenario.delay > 0) {
-      await page.waitForTimeout(scenario.delay);
+      await new Promise(resolve => {
+        setTimeout(resolve, scenario.delay);
+      });
     }
 
     // --- REMOVE SELECTORS ---

--- a/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/Jenkins/Sample/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -14,6 +14,8 @@ module.exports = async (page, scenario) => {
   }
 
   if (postInteractionWait) {
-    await page.waitForTimeout(postInteractionWait);
+    await new Promise(resolve => {
+      setTimeout(resolve, postInteractionWait);
+    });
   }
 };

--- a/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/examples/responsiveDemo/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -19,7 +19,9 @@ module.exports = async (page, scenario) => {
   }
 
   if (postInteractionWait) {
-    await page.waitForTimeout(postInteractionWait);
+    await new Promise(resolve => {
+      setTimeout(resolve, postInteractionWait);
+    });
   }
 
   if (scrollToSelector) {

--- a/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/test/configs/backstop_data/engine_scripts/puppet/clickAndHoverHelper.js
@@ -23,7 +23,9 @@ module.exports = async (page, scenario) => {
   }
 
   if (postInteractionWait) {
-    await page.waitForTimeout(postInteractionWait);
+    await new Promise(resolve => {
+      setTimeout(resolve, postInteractionWait);
+    });
   }
 
   if (scrollToSelector) {


### PR DESCRIPTION
Small fix to address #1553 

In puppeteer waitForTimeout was implemented this way:

```javascript
  /**
   * @deprecated Replace with `new Promise(r => setTimeout(r, milliseconds));`.
   *
   * Causes your script to wait for the given number of milliseconds.
   *
   * @remarks
   * It's generally recommended to not wait for a number of seconds, but instead
   * use {@link Frame.waitForSelector}, {@link Frame.waitForXPath} or
   * {@link Frame.waitForFunction} to wait for exactly the conditions you want.
   *
   * @example
   *
   * Wait for 1 second:
   *
   * ```ts
   * await frame.waitForTimeout(1000);
   * ```
   *
   * @param milliseconds - the number of milliseconds to wait.
   */
  async waitForTimeout(milliseconds: number): Promise<void> {
    return await new Promise(resolve => {
      setTimeout(resolve, milliseconds);
    });
  }
``` 

  
  Therefore it should be sufficient to simply replace function calls with direct setTimeout.