### PR TITLE
Allow puppeteer to connect to a remote chrome instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,11 +747,12 @@ The [storageState](https://playwright.dev/docs/api/class-browsercontext#browser-
 <!-- omit from toc -->
 ### Setting Puppeteer And Playwright Option Flags
 
-Backstop sets two defaults for both Puppeteer and Playwright:
+Backstop sets three defaults for both Puppeteer and Playwright:
 
 ```json
 ignoreHTTPSErrors: true,
-headless: <!!!config.debugWindow>
+headless: <!!!config.debugWindow>,
+remote: false
 ```
 
 You can add more settings (or override the defaults) with the `engineOptions` property. (properties are merged). This is where headless mode can also be set to 'new', until "new headless mode" is less hacky and more supported by Playwright.
@@ -771,6 +772,53 @@ You can add more settings (or override the defaults) with the `engineOptions` pr
 More info here:
   * [Puppeteer on github](https://github.com/GoogleChrome/puppeteer).
   * [Playwright on github](https://github.com/microsoft/playwright).
+
+<!-- omit from toc -->
+#### Running Puppeteer on an already running Chrome instance
+```json
+"engineOptions": {
+  "remote": true,
+  "remoteOptions": {
+    // Note: This ignoreHTTPSErrors is separate from the one in engineOptions, and no default is set for it by BackstopJS.
+    "ignoreHTTPSErrors": false,
+    "browserWSEndpoint": "ws://myremotechrome:9222/devtools/browser/e6447a74-d83f-4f4e-a8e9-388b5216e0c2"
+  }
+}
+```
+
+For more available remoteOptions, check BrowserOptions and ConnectOptions from puppeteer.
+
+Notes for remote mode:
+- Anything outside of remoteOptions is ignored.
+- Chrome has to be launched separately, and BackstopJS has to be able to connect to it.
+  - Args, headless, etc. have to be set for chrome when launching chrome.
+
+<!-- omit from toc -->
+#### Example setup with docker
+
+1. Start a dockerized chrome instance
+  1. E.g `docker run -d -p 9222:9222 --cap-add=SYS_ADMIN justinribeiro/chrome-headless`
+  2. Note the output, it's the docker container ID, e.g `8d203d9598f89028f98389f50a92aab33e18699e502f3813ab584ee654a8ca8a`
+2. Get the devtools web socket
+  1. Use `docker logs <container name or id>` (list these with `docker ps`)
+    1. E.g `docker logs 8d203d9598f89028f98389f50a92aab33e18699e502f3813ab584ee654a8ca8a`
+    2. E.g `docker logs loving_dijkstra`
+  2. Copy the web socket URL from the logs
+    1. E.g, if the logs say `DevTools listening on ws://0.0.0.0:9222/devtools/browser/e6447a74-d83f-4f4e-a8e9-388b5216e0c2`, then the URl is `ws://0.0.0.0:9222/devtools/browser/e6447a74-d83f-4f4e-a8e9-388b5216e0c2`
+3. Create a new or edit an existing BackstopJS config and add these:
+```json
+  "engineOptions": {
+    "remote": true,
+    "remoteOptions": {
+      "browserWSEndpoint": "ws://localhost:9222/devtools/browser/e6447a74-d83f-4f4e-a8e9-388b5216e0c2"
+    }
+  },
+```
+
+If everything went OK, now you should be able to use backstop commands as usual.
+Notes:
+- Since in this example chrome is running in a docker container, it won't see any files on your system, unless they are mounted to it.
+  This means `url: path/to/index.html` scenarios won't work. But making these work is more of a docker topic, not a BackstopJS one.
 
 <!-- omit from toc -->
 ### Using Docker For Testing Across Different Environments
@@ -1193,6 +1241,11 @@ For all engines there is also the `debug` setting.  This enables verbose console
 
 ```json
 "debug": true
+```
+
+Note, this does not work when using
+```json
+"remote": true
 ```
 
 <!-- omit from toc -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.23.6",
         "@babel/preset-react": "^7.23.3",
+        "@types/puppeteer": "^7.0.4",
         "assert": "^2.1.0",
         "babel-loader": "^9.1.3",
         "backstop-twentytwenty": "^1.1.0",
@@ -2749,6 +2750,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/puppeteer": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-7.0.4.tgz",
+      "integrity": "sha512-ja78vquZc8y+GM2al07GZqWDKQskQXygCDiu0e3uO0DMRKqE0MjrFBFmTulfPYzLB6WnL7Kl2tFPy0WXSpPomg==",
+      "deprecated": "This is a stub types definition. puppeteer provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "puppeteer": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@babel/core": "^7.23.6",
     "@babel/preset-env": "^7.23.6",
     "@babel/preset-react": "^7.23.3",
+    "@types/puppeteer": "^7.0.4",
     "assert": "^2.1.0",
     "babel-loader": "^9.1.3",
     "backstop-twentytwenty": "^1.1.0",


### PR DESCRIPTION
- This PR is a fix to the merge conflict from #1005 and an adaptation to the current version of BackstopJS.
- This PR should solve issue #1002.