### PR TITLE
fix(docker): add `:latest` as target during push (#1578)

### DIFF
--- a/.github/workflows/dockerhub-build-push.yml
+++ b/.github/workflows/dockerhub-build-push.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: 🐳 Build & Push to Docker Hub
         run: |
-          docker buildx build --push --platform linux/amd64,linux/arm64 -t backstopjs/backstopjs:$PV --build-arg BACKSTOPJS_VERSION=$PV docker
+          docker buildx build --push --platform linux/amd64,linux/arm64 -t backstopjs/backstopjs:$PV -t backstopjs/backstopjs:latest --build-arg BACKSTOPJS_VERSION=$PV docker


### PR DESCRIPTION
Adds the `:latest` tag to `backstopjs/backstopjs` during the Build & Push GitHub Actions.

Possibly closes #1578 :)