### PR TITLE
fix: handle multibyte characters in scenario label correctly

### DIFF
--- a/core/util/engineTools.js
+++ b/core/util/engineTools.js
@@ -51,7 +51,9 @@ function getSelectorName (selector) {
 }
 
 function makeSafe (str) {
-  return str.replace(/[ /]/g, '_');
+  return str
+    .replace(/[^a-z0-9_-]/gi, (match) => encodeURIComponent(match))
+    .replace(/[ /]/g, '_');
 }
 
 function getFilename (fileNameTemplate, outputFileFormatSuffix, configId, scenarioIndex, scenarioLabelSafe, selectorIndex, selectorLabel, viewportIndex, viewportLabel) {


### PR DESCRIPTION
## Problem
Scenario labels containing multibyte characters (e.g., Japanese, Chinese) were not processed correctly.

For example, when defining a scenario like:
```json
{
  "scenarios": [
    {
      "label": "BackstopJS ホームページ",
      ** other configurations **
    },
    {
      "label": "BackstopJS テストページ",
      ** other configurations **
    }
  ]
}
```

Multibyte characters are ignored in the generated capture filenames,
causing both scenarios to generate the same filename, making it impossible to differentiate between test results.

## Solution
- Fixed the encoding issue when handling scenario labels to ensure multibyte characters are properly retained in capture filenames.
