### PR TITLE
Enable remote to work with spaces and quotes in path

### DIFF
--- a/core/command/remote.js
+++ b/core/command/remote.js
@@ -4,6 +4,20 @@ const { exec } = require('child_process');
 const getRemotePort = require('../util/getRemotePort');
 const ssws = require.resolve('super-simple-web-server');
 
+function wrapPath(pathStr) {
+  if (!pathStr.includes('"')) {
+    return `"${pathStr}"`;
+  }
+
+  // No windows below this point, since double-quotes are not allowed in paths.
+
+  if (!pathStr.includes("'")) {
+    return `'${pathStr}'`;
+  }
+
+  return `"${pathStr.replace(/"/g, '\\"')}"`;
+}
+
 module.exports = {
   execute: function (config) {
     const MIDDLEWARE_PATH = path.resolve(config.backstop, 'remote');
@@ -11,7 +25,7 @@ module.exports = {
 
     return new Promise(function (resolve, reject) {
       const port = getRemotePort();
-      const commandStr = `node ${ssws} ${projectPath} ${MIDDLEWARE_PATH} --config=${config.backstopConfigFileName}`;
+      const commandStr = `node ${wrapPath(ssws)} ${wrapPath(projectPath)} ${wrapPath(MIDDLEWARE_PATH)} --config=${wrapPath(config.backstopConfigFileName)}`;
       const env = { SSWS_HTTP_PORT: port };
 
       logger.log(`Starting remote with: ${commandStr} with env ${JSON.stringify(env)}`);


### PR DESCRIPTION
Should address #1609, without replacing `exec` with `spawn` as #1610 did.

Escaping any argument could be a rather complex thing, but here we only need to handle paths, and that simplifies the solution, because:
- if there is no `"` in the path we can always just wrap it in `"`s
- on windows `"` is not allowed in file names so with this we don't need to think about weird ways of escaping (like `^"` or `""`)
- also, if the path does not contain `'` we can wrap it in `'`s and call it a day
- every other major systems agree on escaping `"` in shell by `\"`, so if both `"` and `'` is present in the path, we replace occurrences of `"` with `\"` and wrap the result in `'`

Also note that BackstopJS remote so far would simply fail for anyone with either `'` or `"` in their path, just like with spaces, so basically no matter what the `wrapPath()` function does, it cannot really make things worse for them.

On the other hand I could make `wrapPath()` return the path without any wrapping if it did not contain a space, that way ensuring exact same behaviour as so far, but with that it'd still be broken for `'` and `"` in the path, so this is a bit more risky, but this way it'll not break with quotation marks in the paths neither.