### PR TITLE
Update openReport.js to wait=true

### DIFF
--- a/core/command/openReport.js
+++ b/core/command/openReport.js
@@ -18,15 +18,15 @@ module.exports = {
         resp.on('end', () => {
           if (BACKSTOP_REPORT_SIGNATURE_RE.test(data)) {
             logger.log('Remote found. Opening ' + remoteReportUrl);
-            resolve(open(remoteReportUrl, { wait: false }));
+            resolve(open(remoteReportUrl, { wait: true }));
           } else {
             logger.log('Remote not detected. Opening ' + config.compareReportURL);
-            resolve(open(config.compareReportURL, { wait: false }));
+            resolve(open(config.compareReportURL, { wait: true }));
           }
         });
       }).on('error', (err) => {
         logger.log('Remote not found. Opening ' + config.compareReportURL, 'Error: ' + err.message);
-        resolve(open(path.resolve(config.compareReportURL), { wait: false }));
+        resolve(open(path.resolve(config.compareReportURL), { wait: true }));
       });
     });
   }


### PR DESCRIPTION
This probably isn't a great solution, but I don't think this project is active anymore anyways.  Mostly just opening this PR hoping that it will help somebody else who runs into the same issue as me.

This may not be advised, but I'm running backstop within a javascript file:
```
const backstop = require('backstopjs');
backstop(command, {
  config: CONFIG_FILE,
  filter
});
```

Any time a scenario compare failed, openReport.js would fail to open the HTML report.  Turns out it was because an uncaught promise exception was causing my application to abort before the broswer window could open.  I was able to resolve this by handling the return promise's error, which ensured the browser window would open:
```
const backstop = require('backstopjs');
backstop(command, {
  config: CONFIG_FILE,
  filter
}).catch(() => {});
```

Unfortunately, this is undocumented and unexpected.  An alternative solution, as proposed by this PR, is to run the `open()` command with config `{ wait: true }`, which prevents the error from being handled before the report opens.