### PR TITLE
chore: Updates to stable Debian and node 24 LTS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # use bullseye node base, as debian does provide a chromium for arm64 and amd64 flavour
-FROM node:20-bullseye
+FROM node:24-trixie
 
 ARG BACKSTOPJS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
I was trying to install some new packages into the docker container on bullseye, but I found bullseye and even bookworm were too old.

This PR updates:

- node LTS release (24)
- Debian stable (trixie)

I ran the following locally:

- npm run init-docker-builder
- npm run build-docker
- npm run build-and-load-docker
- npm run sanity-test-docker
- npm run smoke-test-docker