### PR TITLE
chore: Updates to LTS Debian 12 Bookworm and node 24 LTS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,9 @@ ENV BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION
 
 # install chromium and its deps
 RUN apt-get -qq update >/dev/null && apt-get install -qq \
-  fonts-liberation \
+  fonts-unifont fonts-liberation \
   # cyrillic
-  xfonts-cyrillic \
+  xfonts-cronyx-75dpi \
   # chinese
   xfonts-wqy fonts-wqy-zenhei fonts-arphic-ukai fonts-arphic-uming \
   # japanese

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # use bullseye node base, as debian does provide a chromium for arm64 and amd64 flavour
-FROM node:20-bullseye
+FROM node:24-bookworm
 
 ARG BACKSTOPJS_VERSION
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
I was trying to install some new packages into the docker container on bullseye, but I found bullseye was too old. This replaces #1614.

This PR updates:

- node LTS release (24)
- Debian LTS (bookworm)
   - Replaces xfonts-cyrillic with fonts-unifont and xfonts-cronyx-75dpi. I included both options, but it seems like [Playwright dropped bitmap font support for cyrillic](https://github.com/mxschmitt/playwright/commit/b9e68e22e0d8eebf4f90e63d01408f524812fef2).

I ran the following locally:

- npm run init-docker-builder
- npm run build-docker
- npm run build-and-load-docker
- npm run sanity-test-docker
- npm run smoke-test-docker